### PR TITLE
On-demand per-package vendor indexing with cross-package call-graph stitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,38 +129,55 @@ languages = ["python", "typescript"]
 
 Unknown keys are tolerated for forward-compatibility; type errors on known keys raise with the file path so they're easy to fix.
 
-### Third-party packages (on-demand)
+### Third-party packages (on-demand, isolated per package)
 
-Bulk indexing skips `node_modules/`, `.venv/`, `vendor/`, etc. by default — those trees are huge and rarely what you're searching for. But when you ask a question that *does* need third-party code ("how does Django's `QuerySet.filter` chain"), snapctx auto-detects the package name in the query, ingests just that package on the fly, and answers — all in one call.
+A query can target a third-party package by **prefixing the package name**. No prefix → the repo's own code, full stop. Prefixed → snapctx ensures that one package is indexed (one-time, on demand) and runs the query against the package's *own* isolated index.
 
 ```bash
-snapctx context "django QuerySet filter chain lazy"
+# Repo only — no vendor packages searched.
+snapctx context "session login"
+
+# Routes to django's per-package index. First call ingests just django
+# (one-time ~50s for ~900 files). Subsequent calls are zero-cost.
+snapctx context "django: queryset filter chain lazy"
 # stderr: snapctx: indexing vendor package django at .venv/.../django (one-time)...
 # stderr: snapctx: vendor package django ready (899 files, 14021 symbols).
-# stdout: { "seeds": [...django.db.models.query:QuerySet._chain...] }
+# stdout: { "scope": "django", "seeds": [{ "qname": "db.models.query:QuerySet._chain", ... }] }
 ```
 
-Subsequent queries for django are zero-cost — the package stays indexed until you `vendor forget` it. A regular `snapctx index` won't drop on-demand-indexed packages even though they sit under a normally-skipped directory.
+**Why per-package isolation rather than merging into the repo's index?** Two reasons. (1) Vector-search neighborhoods are sharper over a single coherent corpus — searching for `QuerySet` inside the django scope can't be polluted by the user's own filter classes. (2) Qnames inside the package's index are re-rooted at the package itself, so they look like Django's actual module structure (`db.models.query:QuerySet`) instead of a long `.venv.lib.pythonX.Y.site-packages.django.…` prefix.
 
-**How it picks**: tokenizes the query (case-insensitive, word boundaries), matches tokens *exactly* against installed-package directory names under `<root>/{.venv,venv,env}/lib/python*/site-packages/<name>/` (Python) and `<root>/node_modules/<name>/` (Node, top-level only). No fuzzy matching — "modeling" won't drag in `model`.
+**Storage layout:**
 
-**Manual control:**
+```
+<root>/.snapctx/
+  index.db                  ← repo (default — what queries hit with no prefix)
+  vendor/
+    django/index.db         ← one isolated index per indexed package
+    react/index.db
+```
+
+**Routing rules** for the `<pkg>:` prefix:
+- The head must be a single identifier (letters, digits, underscore, hyphen) — `django.db.models:QuerySet` stays a qname, not a prefix.
+- The head must match a directory under one of the discovered package locations: `<root>/{.venv,venv,env}/lib/python*/site-packages/<name>/` (Python) or `<root>/node_modules/<name>/` (Node, top-level). An already-indexed package also matches even if its source dir was later deleted.
+- No match → no routing, the colon is treated as part of the query (or qname).
+
+**Manual control** for commands that don't take a free-text query (`outline`, `source`, `expand`):
 
 ```bash
-# Force a package without it appearing in the query
-snapctx context "ORM relations" --pkg django
+# Equivalent of writing "django: …" — route this op to django's index.
+snapctx source --pkg django "db.models.query:QuerySet"
 
-# Disable auto-detection for one query (project-only)
-snapctx context "django QuerySet" --no-vendor-packages
-
-# See what's available and what's already indexed
+# See what's been indexed and what's installed (but unindexed).
 snapctx vendor list
 
-# Drop a package's symbols from the index
+# Drop a package's whole index (the .snapctx/vendor/<name>/ directory).
 snapctx vendor forget django
 ```
 
-`--pkg` and `--no-vendor-packages` are available on `search`, `context`, `expand`, `outline`, and `source`.
+`--pkg` is available on `search`, `context`, `expand`, `outline`, and `source`. Multi-root projects: vendor scoping is single-root only — run from inside the specific sub-project that owns the venv.
+
+**Subsequent scoped calls are fast.** A repo query auto-refreshes the repo's index (SHA-skip ~750 ms on a 300-file project). A scoped query *skips* the repo refresh entirely — the repo's index isn't being queried — and the vendor index is built-once-and-forget. End-to-end latency: ~350 ms warm, dominated by fastembed model load. Inside `snapctx watch` (or any long-running process where the model stays loaded) this drops further to single-digit ms.
 
 ---
 
@@ -200,7 +217,7 @@ Returns JSON with `seeds[]` (ranked symbols + bodies + neighbors), `file_outline
 - **No setup**: queries auto-index on first use; auto-refresh on subsequent runs picks up your edits.
 - **No `--root`**: snapctx walks up from CWD to find the nearest `.snapctx/index.db`.
 - **Monorepos**: launching from a parent of indexed sub-projects fans out queries; each result has a `root` field (`"backend"` / `"frontend"`).
-- **Third-party code on demand**: a query that mentions `"django"`, `"react"`, etc. transparently pulls just that package from the project's `.venv` / `node_modules` into the index before answering. Use `--pkg <name>` to force, `--no-vendor-packages` to disable.
+- **Third-party code on demand**: prefix a query with a package name (`"django: queryset filter"`) to route to that package's own isolated index. First use ingests the package; subsequent calls are zero-cost. No prefix → repo only. `--pkg <name>` is the equivalent for ops without a free-text query (`source`, `outline`, `expand`).
 - **Filters**: `--kind function|method|class|component|constant|interface|type` to narrow results.
 
 ### When to fall back to Grep
@@ -231,7 +248,7 @@ snapctx is a local read-mostly CLI. Worth understanding what it touches.
   - Python (`.py`, `.pyi`) and TypeScript (`.ts`, `.tsx`, `.js`, `.jsx`) source — **not** `.env`, credentials, logs, binaries.
   - Respects `.gitignore` — anything excluded there is invisible.
   - Skips `.git`, `.venv`, `node_modules`, `__pycache__`, `.snapctx`, `dist`, `build`, `.tox` by default.
-  - On-demand vendor indexing reads from `.venv/lib/python*/site-packages/<name>/` and `node_modules/<name>/` *only* when a query token matches a package name (or `--pkg <name>` is passed). Disable with `--no-vendor-packages`.
+  - On-demand vendor indexing reads from `.venv/lib/python*/site-packages/<name>/` and `node_modules/<name>/` *only* when a query is prefixed with `<name>:` or `--pkg <name>` is passed. Stored separately under `.snapctx/vendor/<name>/`.
 
 **What it writes:**
 - Exactly one place: `<root>/.snapctx/index.db` (+ WAL/SHM sidecars). Nothing else on disk is ever touched.
@@ -546,7 +563,7 @@ uv pip install --group dev      # or: uv pip install pytest
 pytest
 ```
 
-150+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
+160+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
 
 ---
 
@@ -570,7 +587,7 @@ pytest
 - [x] **Per-repo config** — optional `snapctx.toml` at the root overrides walker defaults (skip dirs, vendor filter, file-size cap, glob include/exclude, language enable list); no config means no behavior change
 - [x] **Multi-root fan-out** — queries from a parent dir hit every indexed sub-project in parallel and tag results with their `root` label
 - [x] **File watcher** (`snapctx watch`) — debounced auto re-index on save, typical run ~5 ms warm
-- [x] **On-demand vendor packages** — query a name like `"django"` and snapctx pulls just that package from `.venv` / `node_modules`, indexes it once, and answers. Survives subsequent regular re-indexes; managed via `snapctx vendor list` / `vendor forget`. `--pkg <name>` for explicit, `--no-vendor-packages` to disable
+- [x] **On-demand vendor packages with per-package isolation** — prefix a query with `<pkg>:` (or pass `--pkg <name>`) and snapctx ingests just that package into its own dedicated index at `.snapctx/vendor/<name>/index.db`, then answers from there. Vector neighborhoods stay focused (no cross-namespace pollution) and qnames re-root at the package (`db.models.query:QuerySet`, not the long venv path). No prefix → repo only. Managed via `snapctx vendor list` / `vendor forget`
 
 **Planned next (snapctx core):**
 - [ ] **`snapctx serve` daemon** — long-running process holds the fastembed model + SQLite handle warm; CLI invocations talk to it over a Unix socket. Closes the ~400 ms cold-CLI gap so every query is 5–10 ms whether or not you have `snapctx watch` running. Lifecycle: auto-start on first query, idle-stop after N minutes, single-instance lock per repo.

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ extra_include = ["vendor/internal-fork/**"]
 extra_exclude = ["docs/generated/**", "**/*.snapshot.tsx"]
 
 # Toggles (defaults match current behavior).
-skip_vendor_bundles = true       # filter .min.js / *-bundle.js / .map / ...
-respect_gitignore   = true       # honor .gitignore
-max_file_size       = 256000     # bytes; default 250 KiB
+skip_vendor_bundles  = true      # filter .min.js / *-bundle.js / .map / ...
+skip_vendor_packages = true      # filter node_modules / .venv / vendor / ...
+respect_gitignore    = true      # honor .gitignore
+max_file_size        = 256000    # bytes; default 250 KiB
 
 # Restrict to specific parsers (default: every parser is active).
 # Valid values: "python", "typescript".
@@ -127,6 +128,39 @@ languages = ["python", "typescript"]
 ```
 
 Unknown keys are tolerated for forward-compatibility; type errors on known keys raise with the file path so they're easy to fix.
+
+### Third-party packages (on-demand)
+
+Bulk indexing skips `node_modules/`, `.venv/`, `vendor/`, etc. by default — those trees are huge and rarely what you're searching for. But when you ask a question that *does* need third-party code ("how does Django's `QuerySet.filter` chain"), snapctx auto-detects the package name in the query, ingests just that package on the fly, and answers — all in one call.
+
+```bash
+snapctx context "django QuerySet filter chain lazy"
+# stderr: snapctx: indexing vendor package django at .venv/.../django (one-time)...
+# stderr: snapctx: vendor package django ready (899 files, 14021 symbols).
+# stdout: { "seeds": [...django.db.models.query:QuerySet._chain...] }
+```
+
+Subsequent queries for django are zero-cost — the package stays indexed until you `vendor forget` it. A regular `snapctx index` won't drop on-demand-indexed packages even though they sit under a normally-skipped directory.
+
+**How it picks**: tokenizes the query (case-insensitive, word boundaries), matches tokens *exactly* against installed-package directory names under `<root>/{.venv,venv,env}/lib/python*/site-packages/<name>/` (Python) and `<root>/node_modules/<name>/` (Node, top-level only). No fuzzy matching — "modeling" won't drag in `model`.
+
+**Manual control:**
+
+```bash
+# Force a package without it appearing in the query
+snapctx context "ORM relations" --pkg django
+
+# Disable auto-detection for one query (project-only)
+snapctx context "django QuerySet" --no-vendor-packages
+
+# See what's available and what's already indexed
+snapctx vendor list
+
+# Drop a package's symbols from the index
+snapctx vendor forget django
+```
+
+`--pkg` and `--no-vendor-packages` are available on `search`, `context`, `expand`, `outline`, and `source`.
 
 ---
 
@@ -166,6 +200,7 @@ Returns JSON with `seeds[]` (ranked symbols + bodies + neighbors), `file_outline
 - **No setup**: queries auto-index on first use; auto-refresh on subsequent runs picks up your edits.
 - **No `--root`**: snapctx walks up from CWD to find the nearest `.snapctx/index.db`.
 - **Monorepos**: launching from a parent of indexed sub-projects fans out queries; each result has a `root` field (`"backend"` / `"frontend"`).
+- **Third-party code on demand**: a query that mentions `"django"`, `"react"`, etc. transparently pulls just that package from the project's `.venv` / `node_modules` into the index before answering. Use `--pkg <name>` to force, `--no-vendor-packages` to disable.
 - **Filters**: `--kind function|method|class|component|constant|interface|type` to narrow results.
 
 ### When to fall back to Grep
@@ -196,6 +231,7 @@ snapctx is a local read-mostly CLI. Worth understanding what it touches.
   - Python (`.py`, `.pyi`) and TypeScript (`.ts`, `.tsx`, `.js`, `.jsx`) source — **not** `.env`, credentials, logs, binaries.
   - Respects `.gitignore` — anything excluded there is invisible.
   - Skips `.git`, `.venv`, `node_modules`, `__pycache__`, `.snapctx`, `dist`, `build`, `.tox` by default.
+  - On-demand vendor indexing reads from `.venv/lib/python*/site-packages/<name>/` and `node_modules/<name>/` *only* when a query token matches a package name (or `--pkg <name>` is passed). Disable with `--no-vendor-packages`.
 
 **What it writes:**
 - Exactly one place: `<root>/.snapctx/index.db` (+ WAL/SHM sidecars). Nothing else on disk is ever touched.
@@ -486,8 +522,10 @@ snapctx/
                         #   + multi-root variants (search_code_multi, context_multi, ...)
     roots.py            # auto-discovery: walk-up to nearest .snapctx, walk-down for sub-projects
     config.py           # snapctx.toml loader (WalkerConfig dataclass; tomllib-backed)
-    cli.py              # argparse entry point (index, search, expand, outline,
-                        #                       source, context, watch, roots)
+    vendor.py           # query-driven on-demand indexing of third-party packages
+                        #   (.venv site-packages, node_modules)
+    cli.py              # argparse entry point (index, search, expand, outline, source,
+                        #                       context, watch, roots, vendor)
   tests/
     fixtures/sample_pkg/
     test_parser.py  test_qname.py  test_api.py  test_constants.py
@@ -508,7 +546,7 @@ uv pip install --group dev      # or: uv pip install pytest
 pytest
 ```
 
-100+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
+150+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
 
 ---
 
@@ -532,6 +570,7 @@ pytest
 - [x] **Per-repo config** — optional `snapctx.toml` at the root overrides walker defaults (skip dirs, vendor filter, file-size cap, glob include/exclude, language enable list); no config means no behavior change
 - [x] **Multi-root fan-out** — queries from a parent dir hit every indexed sub-project in parallel and tag results with their `root` label
 - [x] **File watcher** (`snapctx watch`) — debounced auto re-index on save, typical run ~5 ms warm
+- [x] **On-demand vendor packages** — query a name like `"django"` and snapctx pulls just that package from `.venv` / `node_modules`, indexes it once, and answers. Survives subsequent regular re-indexes; managed via `snapctx vendor list` / `vendor forget`. `--pkg <name>` for explicit, `--no-vendor-packages` to disable
 
 **Planned next (snapctx core):**
 - [ ] **`snapctx serve` daemon** — long-running process holds the fastembed model + SQLite handle warm; CLI invocations talk to it over a Unix socket. Closes the ~400 ms cold-CLI gap so every query is 5–10 ms whether or not you have `snapctx watch` running. Lifecycle: auto-start on first query, idle-stop after N minutes, single-instance lock per repo.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ snapctx vendor forget django
 
 **Subsequent scoped calls are fast.** A repo query auto-refreshes the repo's index (SHA-skip ~750 ms on a 300-file project). A scoped query *skips* the repo refresh entirely — the repo's index isn't being queried — and the vendor index is built-once-and-forget. End-to-end latency: ~350 ms warm, dominated by fastembed model load. Inside `snapctx watch` (or any long-running process where the model stays loaded) this drops further to single-digit ms.
 
+**Cross-package call graph (lazy stitching).** When `expand` or `context` traverses a call inside one indexed package and the callee was imported from *another also-indexed* package, the resolver follows the file's `imports` table to the right sibling index and returns the resolved symbol with a `package` tag. Example: inside django, `tasks.base:Task.call` invokes `async_to_sync`; if you've also indexed `asgiref:`, `expand` returns `{"qname": "sync:async_to_sync", "package": "asgiref", ...}` instead of an unresolved name. Honors the explicit-prefix rule: cross-resolution *only* peeks into packages you've already chosen to index — it never spontaneously fans out into something you didn't ask for. Indexes for the unresolved cross-package call get reported as `unresolved` with the bare callee name, and the user can index that package to see the edge resolve next time.
+
 ---
 
 ## Use it from an AI agent
@@ -563,7 +565,7 @@ uv pip install --group dev      # or: uv pip install pytest
 pytest
 ```
 
-160+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
+170+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
 
 ---
 
@@ -588,6 +590,7 @@ pytest
 - [x] **Multi-root fan-out** — queries from a parent dir hit every indexed sub-project in parallel and tag results with their `root` label
 - [x] **File watcher** (`snapctx watch`) — debounced auto re-index on save, typical run ~5 ms warm
 - [x] **On-demand vendor packages with per-package isolation** — prefix a query with `<pkg>:` (or pass `--pkg <name>`) and snapctx ingests just that package into its own dedicated index at `.snapctx/vendor/<name>/index.db`, then answers from there. Vector neighborhoods stay focused (no cross-namespace pollution) and qnames re-root at the package (`db.models.query:QuerySet`, not the long venv path). No prefix → repo only. Managed via `snapctx vendor list` / `vendor forget`
+- [x] **Cross-package call-graph stitching** — when a call inside one indexed package targets a name imported from another *also-indexed* package, `expand` and `context` follow the import to the sibling index and return the resolved symbol tagged with its package. Lazy (only kicks in when the user has indexed both ends), cached per query operation
 
 **Planned next (snapctx core):**
 - [ ] **`snapctx serve` daemon** — long-running process holds the fastembed model + SQLite handle warm; CLI invocations talk to it over a Unix socket. Closes the ~400 ms cold-CLI gap so every query is 5–10 ms whether or not you have `snapctx watch` running. Lifecycle: auto-start on first query, idle-stop after N minutes, single-instance lock per repo.

--- a/src/snapctx/api/_common.py
+++ b/src/snapctx/api/_common.py
@@ -15,12 +15,25 @@ from pathlib import Path
 from snapctx.index import Index, db_path_for
 
 
-def open_index(root: Path) -> Index:
-    """Open the index for ``root``, raising a friendly error if missing."""
-    db = db_path_for(root)
+def open_index(root: Path, scope: str | None = None) -> Index:
+    """Open the index for ``root`` (or one of its vendor packages).
+
+    ``scope=None`` opens the repo's own index. A non-None scope is the
+    name of a vendor package — opens
+    ``<root>/.snapctx/vendor/<scope>/index.db`` instead. Raises a
+    friendly error when the file doesn't exist; for vendor scopes the
+    caller typically calls ``vendor.ensure_vendor_indexed`` first.
+    """
+    db = db_path_for(root, scope=scope)
     if not db.exists():
+        if scope is None:
+            raise FileNotFoundError(
+                f"No index at {db}. Run `snapctx index {root}` first."
+            )
         raise FileNotFoundError(
-            f"No index at {db}. Run `snapctx index {root}` first."
+            f"No vendor index at {db}. The package {scope!r} hasn't been "
+            f"indexed yet — run a query prefixed with `{scope}:` to "
+            f"ingest it on demand."
         )
     return Index(db)
 

--- a/src/snapctx/api/_context.py
+++ b/src/snapctx/api/_context.py
@@ -48,6 +48,7 @@ def context(
     mode: Literal["lexical", "vector", "hybrid"] = "hybrid",
     kind: str | None = None,
     root: str | Path = ".",
+    scope: str | None = None,
 ) -> dict:
     """Gather everything an agent needs about ``query`` in one call.
 
@@ -75,7 +76,7 @@ def context(
     """
     root_path = Path(root).resolve()
     seeds, candidates, mode = _seeds_for_query(
-        query, root_path, k_seeds, outline_discovery_k, kind, mode
+        query, root_path, k_seeds, outline_discovery_k, kind, mode, scope=scope,
     )
 
     if not seeds:
@@ -87,7 +88,7 @@ def context(
             "token_estimate": 0,
         }
 
-    idx = open_index(root_path)
+    idx = open_index(root_path, scope=scope)
     try:
         enriched = [
             _enrich_seed(
@@ -103,12 +104,14 @@ def context(
     finally:
         idx.close()
 
-    payload = {
+    payload: dict = {
         "query": query,
         "mode": mode,
         "seeds": enriched,
         "file_outlines": file_outlines,
     }
+    if scope is not None:
+        payload["scope"] = scope
     payload["token_estimate"] = rough_token_count(payload)
     payload["hint"] = (
         "This response bundles search + callees + callers + top sources + a file outline. "
@@ -124,6 +127,8 @@ def _seeds_for_query(
     outline_discovery_k: int,
     kind: str | None,
     mode: str,
+    *,
+    scope: str | None = None,
 ) -> tuple[list[dict], list[dict], str]:
     """Return ``(visible_seeds, broader_candidates, effective_mode)``.
 
@@ -132,7 +137,7 @@ def _seeds_for_query(
     the original mode.
     """
     if ":" in query:
-        idx_tmp = open_index(root_path)
+        idx_tmp = open_index(root_path, scope=scope)
         try:
             direct = idx_tmp.get_symbol(query)
         finally:
@@ -151,7 +156,8 @@ def _seeds_for_query(
             return [seed], [seed], "exact"
 
     search_result = search_code(
-        query, k=max(k_seeds, outline_discovery_k), kind=kind, root=root_path, mode=mode
+        query, k=max(k_seeds, outline_discovery_k), kind=kind,
+        root=root_path, mode=mode, scope=scope,
     )
     candidates = search_result["results"]
     return candidates[:k_seeds], candidates, mode

--- a/src/snapctx/api/_context.py
+++ b/src/snapctx/api/_context.py
@@ -88,7 +88,9 @@ def context(
             "token_estimate": 0,
         }
 
+    from snapctx.api._cross_package import CrossPackageResolver
     idx = open_index(root_path, scope=scope)
+    resolver = CrossPackageResolver(root_path, current_scope=scope)
     try:
         enriched = [
             _enrich_seed(
@@ -97,11 +99,13 @@ def context(
                 expand_depth=expand_depth,
                 source_for_top=source_for_top,
                 body_char_cap=body_char_cap,
+                resolver=resolver,
             )
             for i, seed in enumerate(seeds)
         ]
         file_outlines = _file_outlines(idx, candidates, file_outline_limit)
     finally:
+        resolver.close()
         idx.close()
 
     payload: dict = {
@@ -172,6 +176,7 @@ def _enrich_seed(
     expand_depth: int,
     source_for_top: int,
     body_char_cap: int,
+    resolver=None,
 ) -> dict:
     """Attach callees/callers, source, and (for constants) alias resolution."""
     qname = seed["qname"]
@@ -189,8 +194,14 @@ def _enrich_seed(
         entry["decorators"] = seed["decorators"]
 
     depth = max(1, expand_depth)
-    callees = collect_neighbors(idx, qname, direction="callees", limit=neighbor_limit, depth=depth)
-    callers = collect_neighbors(idx, qname, direction="callers", limit=neighbor_limit, depth=depth)
+    callees = collect_neighbors(
+        idx, qname, direction="callees",
+        limit=neighbor_limit, depth=depth, resolver=resolver,
+    )
+    callers = collect_neighbors(
+        idx, qname, direction="callers",
+        limit=neighbor_limit, depth=depth, resolver=resolver,
+    )
     if callees:
         entry["callees"] = callees
     if callers:

--- a/src/snapctx/api/_cross_package.py
+++ b/src/snapctx/api/_cross_package.py
@@ -1,0 +1,179 @@
+"""Cross-package call resolution at query time.
+
+When a call inside a vendor package's index has ``callee_qname=NULL``
+(unresolved at parse time), the symbol may live in a *different* vendor
+package whose index has also been built. This resolver:
+
+1. Looks at the imports of the calling file.
+2. Matches the callee name against import names / aliases / module paths.
+3. Identifies which package the symbol is supposed to come from (first
+   component of the imported module path).
+4. If that package has an index at
+   ``<repo_root>/.snapctx/vendor/<pkg>/index.db``, opens it and searches
+   for the resolved qname.
+
+Honors the explicit-prefix rule: we *only* peek into packages that the
+user has already chosen to index — never spontaneously fan out into
+something that wasn't requested.
+
+Resolved hits carry a ``package`` tag so the consumer can distinguish
+in-package edges from cross-package edges in expand / context output.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from snapctx.index import Index, db_path_for
+
+# Names that are never worth cross-resolving: ``self.X`` is intra-class
+# (handled by promote_self_calls); ``super.X`` is dynamic; bare builtins
+# like ``isinstance`` aren't installed packages.
+_NOISE_PREFIXES = ("self.", "this.", "super.", "cls.")
+
+
+class CrossPackageResolver:
+    """Per-operation cache of opened sibling indexes + import tables.
+
+    Lifetime is one expand / context call. An ``expand`` that traverses
+    50 cross-package edges shouldn't reopen the same DB 50 times, and
+    shouldn't re-query imports for the same file 50 times.
+    """
+
+    def __init__(self, repo_root: Path, current_scope: str | None) -> None:
+        self.repo_root = repo_root
+        self.current_scope = current_scope
+        self._open: dict[str, Index | None] = {}
+        self._imports: dict[str, list[sqlite3.Row]] = {}
+
+    def close(self) -> None:
+        for idx in self._open.values():
+            if idx is not None:
+                idx.close()
+        self._open.clear()
+
+    def __enter__(self) -> CrossPackageResolver:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def _open_pkg(self, name: str) -> Index | None:
+        if name in self._open:
+            return self._open[name]
+        if name == self.current_scope:
+            self._open[name] = None  # don't traverse into our own index
+            return None
+        db = db_path_for(self.repo_root, scope=name)
+        if not db.exists():
+            self._open[name] = None
+            return None
+        idx = Index(db)
+        self._open[name] = idx
+        return idx
+
+    def _imports_for(self, caller_idx: Index, file: str) -> list[sqlite3.Row]:
+        rows = self._imports.get(file)
+        if rows is None:
+            rows = caller_idx.imports_for_file(file)
+            self._imports[file] = rows
+        return rows
+
+    def resolve(
+        self, callee_name: str, caller_file: str, caller_idx: Index
+    ) -> dict | None:
+        """Try to resolve ``callee_name`` into a sibling vendor package.
+
+        Returns ``{"package": str, "row": sqlite3.Row}`` on a hit; ``None``
+        otherwise. The row is from the resolved package's index — same
+        schema as the home index's ``symbols`` table.
+        """
+        if not callee_name:
+            return None
+        if any(callee_name.startswith(p) for p in _NOISE_PREFIXES):
+            return None
+
+        parts = callee_name.split(".")
+        head = parts[0]
+        rest = parts[1:]
+
+        for imp in self._imports_for(caller_idx, caller_file):
+            module = imp["module"]
+            name = imp["name"]
+            alias = imp["alias"]
+            if not module:
+                continue
+
+            # Three import shapes drive different chain construction.
+            if name is not None:
+                # ``from <module> import <name> [as <alias>]``
+                bound = alias or name
+                if bound != head:
+                    continue
+                target_pkg = module.split(".")[0]
+                in_pkg_module = (
+                    "" if module == target_pkg
+                    else module[len(target_pkg) + 1:]
+                )
+                # The bound name itself is the imported symbol; ``rest``
+                # is whatever method / attribute chain follows.
+                full_chain = [name, *rest]
+            else:
+                # ``import <module> [as <alias>]``
+                bound = alias or module.split(".")[0]
+                if bound != head:
+                    continue
+                target_pkg = module.split(".")[0]
+                in_pkg_module = (
+                    "" if module == target_pkg
+                    else module[len(target_pkg) + 1:]
+                )
+                if alias is None:
+                    # ``import asgiref.sync`` then ``asgiref.sync.X(...)`` —
+                    # the rest re-traverses the module path that
+                    # ``in_pkg_module`` already represents. Skip those parts.
+                    skip = (
+                        len(in_pkg_module.split(".")) if in_pkg_module else 0
+                    )
+                    full_chain = rest[skip:]
+                else:
+                    # Alias replaces the full module reference; rest starts
+                    # immediately after the alias.
+                    full_chain = list(rest)
+
+            pkg_idx = self._open_pkg(target_pkg)
+            if pkg_idx is None:
+                continue
+
+            for cand in _candidate_qnames(in_pkg_module, full_chain):
+                row = pkg_idx.get_symbol(cand)
+                if row is not None:
+                    return {"package": target_pkg, "row": row}
+
+        return None
+
+
+def _candidate_qnames(in_pkg_module: str, chain: list[str]) -> list[str]:
+    """Generate qname shapes to try for a (module, dotted-name-chain) target.
+
+    The qname grammar is ``<module>:<member.path>``; given a chain of N
+    parts, we don't statically know which prefix is part of the module
+    path vs the member path. Enumerate progressively: at split index
+    ``i``, parts ``[:i]`` extend the module and parts ``[i:]`` form the
+    member. The caller checks each candidate against the package's
+    symbols table.
+    """
+    if not chain:
+        # Imported the package or module itself with no further access.
+        return [f"{in_pkg_module}:"] if in_pkg_module else [":"]
+    out: list[str] = []
+    for i in range(len(chain)):
+        mod_extra = ".".join(chain[:i])
+        member = ".".join(chain[i:])
+        if mod_extra:
+            mod = f"{in_pkg_module}.{mod_extra}" if in_pkg_module else mod_extra
+        else:
+            mod = in_pkg_module
+        out.append(f"{mod}:{member}")
+    return out

--- a/src/snapctx/api/_graph.py
+++ b/src/snapctx/api/_graph.py
@@ -24,6 +24,7 @@ from snapctx.api._common import (
     open_index,
     row_to_symbol_dict,
 )
+from snapctx.api._cross_package import CrossPackageResolver
 from snapctx.index import Index
 
 
@@ -110,6 +111,7 @@ def expand(
     """
     root_path = Path(root).resolve()
     idx = open_index(root_path, scope=scope)
+    resolver = CrossPackageResolver(root_path, current_scope=scope)
     try:
         root_sym = idx.get_symbol(qname)
         if root_sym is None:
@@ -127,17 +129,23 @@ def expand(
             next_frontier: list[str] = []
             layer: list[dict] = []
             for source_qname in frontier:
-                for neigh_qname, neigh_row, edge_kind, call_line in _neighbors(
-                    idx, source_qname, direction
+                for neigh_qname, neigh_row, edge_kind, call_line, pkg in _neighbors(
+                    idx, source_qname, direction, resolver,
                 ):
                     if neigh_qname in visited:
                         continue
                     visited.add(neigh_qname)
-                    next_frontier.append(neigh_qname)
+                    # Cross-package neighbors live in another index, so
+                    # we can't traverse their callees/callers from the
+                    # current frontier — keep them as terminal entries.
+                    if pkg is None:
+                        next_frontier.append(neigh_qname)
                     entry = {"from": source_qname, "edge": edge_kind, "line": call_line}
                     if neigh_row is not None:
                         entry.update(row_to_symbol_dict(neigh_row))
                         entry["docstring"] = docstring_summary(neigh_row["docstring"])
+                        if pkg is not None:
+                            entry["package"] = pkg
                     else:
                         entry["qname"] = neigh_qname
                         entry["resolved"] = False
@@ -156,24 +164,43 @@ def expand(
             "hint": _expand_hint(layers),
         }
     finally:
+        resolver.close()
         idx.close()
 
 
 def _neighbors(
-    idx: Index, qname: str, direction: str
-) -> list[tuple[str, sqlite3.Row | None, str, int]]:
-    """Return (neighbor_qname, neighbor_symbol_row_or_None, edge_kind, line) tuples."""
-    out: list[tuple[str, sqlite3.Row | None, str, int]] = []
+    idx: Index, qname: str, direction: str, resolver: CrossPackageResolver,
+) -> list[tuple[str, sqlite3.Row | None, str, int, str | None]]:
+    """Return (neighbor_qname, neighbor_symbol_row_or_None, edge_kind, line, package_or_None) tuples.
+
+    ``package`` is non-None when the neighbor was resolved by following an
+    import into a sibling vendor package's index; in that case the row
+    comes from that other index.
+    """
+    out: list[tuple[str, sqlite3.Row | None, str, int, str | None]] = []
     if direction in ("callees", "both"):
         for row in idx.callees_of(qname):
-            neigh_qname = row["callee_qname"] or f"?:{row['callee_name']}"
-            sym = idx.get_symbol(neigh_qname) if row["callee_qname"] else None
-            out.append((neigh_qname, sym, "callee", row["line"]))
+            if row["callee_qname"]:
+                sym = idx.get_symbol(row["callee_qname"])
+                out.append((row["callee_qname"], sym, "callee", row["line"], None))
+                continue
+            cross = resolver.resolve(
+                row["callee_name"], row["file"], idx,
+            )
+            if cross is not None:
+                pkg = cross["package"]
+                xrow = cross["row"]
+                tagged_qname = f"{pkg}::{xrow['qname']}"
+                out.append((tagged_qname, xrow, "callee", row["line"], pkg))
+                continue
+            out.append(
+                (f"?:{row['callee_name']}", None, "callee", row["line"], None)
+            )
     if direction in ("callers", "both"):
         for row in idx.callers_of(qname):
             neigh_qname = row["caller_qname"]
             sym = idx.get_symbol(neigh_qname)
-            out.append((neigh_qname, sym, "caller", row["line"]))
+            out.append((neigh_qname, sym, "caller", row["line"], None))
     return out
 
 
@@ -210,6 +237,7 @@ def collect_neighbors(
     direction: Literal["callees", "callers"],
     limit: int,
     depth: int,
+    resolver: CrossPackageResolver | None = None,
 ) -> list[dict]:
     """Gather direction-specific neighbors of ``qname`` up to ``depth`` hops.
 
@@ -217,6 +245,12 @@ def collect_neighbors(
     or ``callers`` (when direction='callers') with the next hop's neighbors.
     Unresolved entries never recurse — we don't know what they call. Depth-2
     neighbors use a tighter limit (half, minimum 3) to keep payloads bounded.
+
+    ``resolver`` enables cross-package fallback: when a callee is unresolved
+    in this index, attempt to resolve it via the file's imports against
+    sibling vendor indexes that have already been built. Cross-package
+    hits are tagged with a ``package`` field and don't recurse (their own
+    callees live in the other index).
     """
     rows = idx.callees_of(qname) if direction == "callees" else idx.callers_of(qname)
     out: list[dict] = []
@@ -235,9 +269,17 @@ def collect_neighbors(
                         nested = collect_neighbors(
                             idx, neigh_qname, direction=direction,
                             limit=max(3, limit // 2), depth=depth - 1,
+                            resolver=resolver,
                         )
                         if nested:
                             entry["callees"] = nested
+                    out.append(entry)
+                    continue
+            if resolver is not None:
+                cross = resolver.resolve(row["callee_name"], row["file"], idx)
+                if cross is not None:
+                    entry = neighbor_entry(cross["row"], row["line"])
+                    entry["package"] = cross["package"]
                     out.append(entry)
                     continue
             out.append({"qname": neigh_qname, "line": row["line"], "resolved": False})
@@ -250,6 +292,7 @@ def collect_neighbors(
                 nested = collect_neighbors(
                     idx, row["caller_qname"], direction=direction,
                     limit=max(3, limit // 2), depth=depth - 1,
+                    resolver=resolver,
                 )
                 if nested:
                     entry["callers"] = nested

--- a/src/snapctx/api/_graph.py
+++ b/src/snapctx/api/_graph.py
@@ -94,6 +94,7 @@ def expand(
     direction: Literal["callees", "callers", "both"] = "callees",
     depth: int = 1,
     root: str | Path = ".",
+    scope: str | None = None,
 ) -> dict:
     """Walk the call graph from ``qname`` and return neighbor signatures.
 
@@ -108,7 +109,7 @@ def expand(
     so the caller can decide which ones (if any) need `get_source`.
     """
     root_path = Path(root).resolve()
-    idx = open_index(root_path)
+    idx = open_index(root_path, scope=scope)
     try:
         root_sym = idx.get_symbol(qname)
         if root_sym is None:

--- a/src/snapctx/api/_indexer.py
+++ b/src/snapctx/api/_indexer.py
@@ -41,14 +41,31 @@ def index_root(root: str | Path) -> dict:
     cfg = load_config(root_path)
     idx = Index(db_path_for(root_path))
     counts = {"scanned": 0, "updated": 0, "skipped": 0, "symbols": 0, "removed": 0}
+    moved = False
 
     try:
+        # If the project was renamed/moved on disk, every stored absolute
+        # path is now stale. Detect via a sample row's prefix and wipe so
+        # the rebuild below repopulates with current paths. Cheaper than
+        # rewriting every row in-place, and avoids the path-mismatch trap
+        # where the staleness diff would forget every old row anyway —
+        # except the auto-refresh transaction would then hit the explicit-
+        # BEGIN-vs-implicit-BEGIN race that this commit also fixes.
+        moved = _wipe_if_root_moved(idx, root_path)
+
         # Snapshot the current filesystem view and diff it against the DB so
         # rows for files that have been deleted / renamed / .gitignored go
         # away. Without this, stale symbols and call edges accumulate.
         walker_files = {str(f.resolve()) for f in iter_source_files(root_path, cfg.walker)}
         db_files = {row["path"] for row in idx.conn.execute("SELECT path FROM files").fetchall()}
+        # Files brought in by on-demand vendor indexing live outside the
+        # walker's view (they're under .venv / node_modules, gitignored).
+        # Without this guard, every regular re-index would forget them —
+        # and the next vendor query would have to ingest django from scratch.
+        vendor_prefixes = tuple(p.rstrip("/") + "/" for p in idx.vendor_paths())
         for stale in db_files - walker_files:
+            if vendor_prefixes and stale.startswith(vendor_prefixes):
+                continue
             idx.forget_file(stale)
             counts["removed"] += 1
 
@@ -82,6 +99,90 @@ def index_root(root: str | Path) -> dict:
         "files_updated": counts["updated"],
         "files_unchanged": counts["skipped"],
         "files_removed": counts["removed"],
+        "symbols_indexed": counts["symbols"],
+        "calls_demoted": demoted,
+        "symbols_embedded": embedded,
+        "root_moved": moved,
+    }
+
+
+def _wipe_if_root_moved(idx: Index, root_path: Path) -> bool:
+    """Drop all rows when stored paths don't sit under the current root.
+
+    Heuristic: look at one ``files.path`` row. If it isn't a child of
+    ``root_path``, the project was renamed/moved (or the index was copied
+    into a sibling repo). Wiping is cheaper than rewriting every absolute
+    path in symbols/calls/imports/files.
+    """
+    sample = idx.conn.execute("SELECT path FROM files LIMIT 1").fetchone()
+    if sample is None:
+        return False
+    sample_path = Path(sample["path"])
+    try:
+        sample_path.relative_to(root_path)
+    except ValueError:
+        idx.wipe_all()
+        return True
+    return False
+
+
+def index_subtree(project_root: str | Path, subtree: str | Path) -> dict:
+    """Ingest one subtree into the project's index without touching unrelated rows.
+
+    Used for on-demand vendor-package indexing: the caller has matched a
+    query token against an installed package and wants just *that* package
+    pulled into the existing index. Differs from ``index_root`` in two
+    ways: (1) walks only the subtree, and (2) skips the staleness diff
+    entirely — the rest of the project's files are still in the DB and
+    we must not forget them.
+
+    Parsers receive ``project_root`` for qname computation so symbols
+    indexed here share the same namespace as the rest of the project
+    (``.venv.lib.python3.14.site-packages.django.db.models.query:QuerySet``).
+    """
+    from snapctx.config import WalkerConfig
+    from snapctx.index import sha_bytes
+    from snapctx.parsers.registry import parser_for
+    from snapctx.walker import iter_source_files
+
+    project_root = Path(project_root).resolve()
+    subtree = Path(subtree).resolve()
+    idx = Index(db_path_for(project_root))
+    counts = {"updated": 0, "skipped": 0, "symbols": 0}
+
+    # Vendor-package code: don't honor gitignore (the venv is gitignored
+    # by definition), don't skip vendor dirs (we're inside one), keep the
+    # bundle filter (.min.js inside node_modules is still noise).
+    cfg = WalkerConfig(
+        skip_vendor_packages=False,
+        respect_gitignore=False,
+    )
+
+    try:
+        for file in iter_source_files(subtree, cfg):
+            file_str = str(file.resolve())
+            data = file.read_bytes()
+            sha = sha_bytes(data)
+            if idx.current_sha(file_str) == sha:
+                counts["skipped"] += 1
+                continue
+            parser = parser_for(file.suffix)
+            assert parser is not None
+            result = parser.parse(file, project_root)
+            idx.ingest(file_str, parser.language, sha, result)
+            counts["updated"] += 1
+            counts["symbols"] += len(result.symbols)
+
+        demoted = idx.demote_unresolved_calls()
+        idx.promote_self_calls()
+        embedded = _embed_missing(idx)
+    finally:
+        idx.close()
+
+    return {
+        "subtree": str(subtree),
+        "files_updated": counts["updated"],
+        "files_unchanged": counts["skipped"],
         "symbols_indexed": counts["symbols"],
         "calls_demoted": demoted,
         "symbols_embedded": embedded,

--- a/src/snapctx/api/_indexer.py
+++ b/src/snapctx/api/_indexer.py
@@ -58,14 +58,7 @@ def index_root(root: str | Path) -> dict:
         # away. Without this, stale symbols and call edges accumulate.
         walker_files = {str(f.resolve()) for f in iter_source_files(root_path, cfg.walker)}
         db_files = {row["path"] for row in idx.conn.execute("SELECT path FROM files").fetchall()}
-        # Files brought in by on-demand vendor indexing live outside the
-        # walker's view (they're under .venv / node_modules, gitignored).
-        # Without this guard, every regular re-index would forget them —
-        # and the next vendor query would have to ingest django from scratch.
-        vendor_prefixes = tuple(p.rstrip("/") + "/" for p in idx.vendor_paths())
         for stale in db_files - walker_files:
-            if vendor_prefixes and stale.startswith(vendor_prefixes):
-                continue
             idx.forget_file(stale)
             counts["removed"] += 1
 
@@ -126,40 +119,47 @@ def _wipe_if_root_moved(idx: Index, root_path: Path) -> bool:
     return False
 
 
-def index_subtree(project_root: str | Path, subtree: str | Path) -> dict:
-    """Ingest one subtree into the project's index without touching unrelated rows.
+def index_vendor_package(
+    repo_root: str | Path, name: str, pkg_path: str | Path
+) -> dict:
+    """Ingest one third-party package into its own dedicated index.
 
-    Used for on-demand vendor-package indexing: the caller has matched a
-    query token against an installed package and wants just *that* package
-    pulled into the existing index. Differs from ``index_root`` in two
-    ways: (1) walks only the subtree, and (2) skips the staleness diff
-    entirely — the rest of the project's files are still in the DB and
-    we must not forget them.
+    Storage: ``<repo_root>/.snapctx/vendor/<name>/index.db``. Completely
+    isolated from the repo's index — separate symbols, separate FTS, and
+    most importantly separate vector matrix so cosine search inside the
+    package isn't polluted by cross-namespace neighbors.
 
-    Parsers receive ``project_root`` for qname computation so symbols
-    indexed here share the same namespace as the rest of the project
-    (``.venv.lib.python3.14.site-packages.django.db.models.query:QuerySet``).
+    The parser is rooted at ``pkg_path`` (not ``repo_root``), so qnames
+    inside this index look like ``db.models.query:QuerySet`` — the
+    package's own module structure — instead of carrying a long
+    ``.venv.lib.python*.site-packages.django.…`` prefix.
     """
     from snapctx.config import WalkerConfig
     from snapctx.index import sha_bytes
     from snapctx.parsers.registry import parser_for
     from snapctx.walker import iter_source_files
 
-    project_root = Path(project_root).resolve()
-    subtree = Path(subtree).resolve()
-    idx = Index(db_path_for(project_root))
+    repo_root = Path(repo_root).resolve()
+    pkg_path = Path(pkg_path).resolve()
+    idx = Index(db_path_for(repo_root, scope=name))
     counts = {"updated": 0, "skipped": 0, "symbols": 0}
 
-    # Vendor-package code: don't honor gitignore (the venv is gitignored
-    # by definition), don't skip vendor dirs (we're inside one), keep the
-    # bundle filter (.min.js inside node_modules is still noise).
+    # Inside a venv / node_modules: gitignore would block us, vendor-skip
+    # would block us — disable both. Bundle filter stays on so a
+    # ``react/dist/react.min.js`` doesn't pollute the index.
     cfg = WalkerConfig(
         skip_vendor_packages=False,
         respect_gitignore=False,
     )
 
     try:
-        for file in iter_source_files(subtree, cfg):
+        # Same rename-detection trick as the repo index — if the package
+        # was reinstalled (uv / pip --upgrade), the absolute paths in our
+        # DB no longer resolve. Wipe and rebuild instead of dragging stale
+        # rows forward.
+        moved = _wipe_if_root_moved(idx, pkg_path)
+
+        for file in iter_source_files(pkg_path, cfg):
             file_str = str(file.resolve())
             data = file.read_bytes()
             sha = sha_bytes(data)
@@ -168,7 +168,7 @@ def index_subtree(project_root: str | Path, subtree: str | Path) -> dict:
                 continue
             parser = parser_for(file.suffix)
             assert parser is not None
-            result = parser.parse(file, project_root)
+            result = parser.parse(file, pkg_path)
             idx.ingest(file_str, parser.language, sha, result)
             counts["updated"] += 1
             counts["symbols"] += len(result.symbols)
@@ -180,12 +180,14 @@ def index_subtree(project_root: str | Path, subtree: str | Path) -> dict:
         idx.close()
 
     return {
-        "subtree": str(subtree),
+        "package": name,
+        "package_path": str(pkg_path),
         "files_updated": counts["updated"],
         "files_unchanged": counts["skipped"],
         "symbols_indexed": counts["symbols"],
         "calls_demoted": demoted,
         "symbols_embedded": embedded,
+        "package_moved": moved,
     }
 
 

--- a/src/snapctx/api/_retrieve.py
+++ b/src/snapctx/api/_retrieve.py
@@ -18,7 +18,7 @@ from snapctx.api._common import (
 )
 
 
-def outline(path: str | Path, root: str | Path = ".") -> dict:
+def outline(path: str | Path, root: str | Path = ".", scope: str | None = None) -> dict:
     """List all symbols defined in a file, nested by parent.
 
     Accepts an absolute path or a path relative to ``root``. Returns the file's
@@ -31,10 +31,20 @@ def outline(path: str | Path, root: str | Path = ".") -> dict:
     root_path = Path(root).resolve()
     target = Path(path)
     if not target.is_absolute():
-        target = (root_path / target).resolve()
+        # In a vendor scope, relative paths are relative to the package's
+        # own root (the package dir), not the repo root, since that's how
+        # files are anchored in the per-package index.
+        from snapctx.vendor import vendor_index_dir
+        if scope is not None:
+            from snapctx.vendor import discover_packages
+            pkg = discover_packages(root_path).get(scope)
+            anchor = pkg or vendor_index_dir(root_path, scope).parent
+            target = (anchor / target).resolve()
+        else:
+            target = (root_path / target).resolve()
     file_str = str(target)
 
-    idx = open_index(root_path)
+    idx = open_index(root_path, scope=scope)
     try:
         rows = idx.symbols_in_file(file_str)
     finally:
@@ -77,6 +87,7 @@ def get_source(
     qname: str,
     with_neighbors: bool = False,
     root: str | Path = ".",
+    scope: str | None = None,
 ) -> dict:
     """Return the full source of a symbol, and optionally the signatures of what it calls.
 
@@ -85,7 +96,7 @@ def get_source(
     about the dependency context without a follow-up round-trip.
     """
     root_path = Path(root).resolve()
-    idx = open_index(root_path)
+    idx = open_index(root_path, scope=scope)
     try:
         row = idx.get_symbol(qname)
         if row is None:

--- a/src/snapctx/api/_search.py
+++ b/src/snapctx/api/_search.py
@@ -31,6 +31,7 @@ def search_code(
     kind: Literal["function", "method", "class", "module", "interface", "type", "component", "constant"] | None = None,
     root: str | Path = ".",
     mode: Literal["lexical", "vector", "hybrid"] = "hybrid",
+    scope: str | None = None,
 ) -> dict:
     """Find symbols whose qname, signature, docstring, or decorators match ``query``.
 
@@ -48,7 +49,7 @@ def search_code(
     ``enough`` when the docstring alone is self-explanatory).
     """
     root_path = Path(root).resolve()
-    idx = open_index(root_path)
+    idx = open_index(root_path, scope=scope)
     try:
         fts_query = build_fts_query(query)
         overfetch = k * 3
@@ -81,9 +82,12 @@ def search_code(
         d["next_action"] = suggest_next_action(row)
         results.append(d)
 
-    return {
+    response: dict = {
         "query": query,
         "mode": mode,
         "results": results,
         "hint": search_hint(results),
     }
+    if scope is not None:
+        response["scope"] = scope
+    return response

--- a/src/snapctx/cli.py
+++ b/src/snapctx/cli.py
@@ -33,7 +33,13 @@ from snapctx.api import (
     search_code_multi,
 )
 from snapctx.roots import discover_roots, root_label
-from snapctx.vendor import discover_packages, ensure_packages_for_query
+from snapctx.vendor import (
+    discover_packages,
+    ensure_vendor_indexed,
+    forget_vendor,
+    list_indexed_vendors,
+    parse_query_prefix,
+)
 from snapctx.watch import run_watch
 
 
@@ -64,9 +70,19 @@ class QueryCommand:
 
     def call(self, args: argparse.Namespace, roots: list[Path], anchor: Path) -> dict:
         kwargs = {a: getattr(args, a) for a in self.arg_names}
+        scope = getattr(args, "scope", None)
         if len(roots) > 1:
+            if scope is not None:
+                # v1 simplification: vendor packages are per-root, and we
+                # don't have a meaningful "merge X across N vendor indexes"
+                # story yet. Surface the conflict explicitly.
+                raise SystemExit(
+                    f"snapctx: vendor scope ({scope!r}) is not supported across "
+                    f"multiple roots. Run from inside one of: "
+                    f"{', '.join(str(r) for r in roots)}"
+                )
             return self.multi(roots=roots, anchor=anchor, **kwargs)
-        return self.single(root=roots[0], **kwargs)
+        return self.single(root=roots[0], scope=scope, **kwargs)
 
 
 _QUERY_COMMANDS: tuple[QueryCommand, ...] = (
@@ -184,26 +200,17 @@ def _refresh_indexes(roots: list[Path]) -> None:
 
 
 def _add_vendor_args(p: argparse.ArgumentParser) -> None:
-    """Attach the vendor-package flags shared by every query command.
+    """Attach the vendor-scope flag shared by every query command.
 
-    ``--pkg`` forces a specific package to be indexed (repeatable). It's
-    the escape hatch for cases where the package name doesn't appear
-    verbatim in the query but the user knows they need it (e.g. asking
-    about 'ORM' but wanting Django source).
-
-    ``--no-vendor-packages`` disables the auto-detection that scans the
-    free-text query for installed-package names. Useful when you want a
-    pure project-only result without the latency of a first-time vendor
-    ingest.
+    ``--pkg <name>`` is the explicit form of the ``<pkg>:`` query prefix:
+    route this query to the per-package index for ``<name>`` instead of
+    the repo's. Useful when the operation doesn't take a free-text query
+    (``outline``, ``source``, ``expand``) so the prefix-in-query trick
+    doesn't apply.
     """
     p.add_argument(
-        "--pkg", action="append", default=[], metavar="NAME",
-        help="Index this third-party package on demand (repeatable).",
-    )
-    p.add_argument(
-        "--no-vendor-packages", dest="auto_vendor",
-        action="store_false", default=True,
-        help="Don't auto-index packages whose name appears in the query.",
+        "--pkg", default=None, metavar="NAME",
+        help="Run against the named vendor package's index (e.g. --pkg django).",
     )
 
 
@@ -322,19 +329,21 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "vendor":
         return _vendor_dispatch(args)
 
-    # Query commands: discover, ensure index is fresh, dispatch.
+    # Query commands: discover, resolve scope, ensure relevant index is fresh, dispatch.
     roots, anchor = _resolve_roots(args.root)
     if not roots:
         roots = _bootstrap_first_index(anchor)
         if not roots:
             return 2
-    else:
-        # Incremental refresh — picks up edits since the last query so
-        # results always reflect current code. Cheap (SHA-skip) when
-        # nothing changed.
-        _refresh_indexes(roots)
 
-    _ensure_query_vendor_packages(roots, args)
+    # Scope resolution is cheap (~3 ms) so we run it BEFORE the repo
+    # auto-refresh: if the query is scoped to a vendor package, the repo's
+    # index isn't being queried and SHA-skipping its 300+ files is pure
+    # waste (~750 ms on a real project). Vendor packages are
+    # built-once-and-forget — no per-call refresh needed.
+    _resolve_query_scope(roots, args)
+    if args.scope is None:
+        _refresh_indexes(roots)
 
     cmd = _QUERY_BY_NAME.get(args.cmd)
     if cmd is None:
@@ -345,29 +354,51 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _ensure_query_vendor_packages(roots: list[Path], args: argparse.Namespace) -> None:
-    """Index vendor packages referenced by this query, if any.
+def _resolve_query_scope(roots: list[Path], args: argparse.Namespace) -> None:
+    """Pick the right index for this query: repo's own, or one vendor package's.
 
-    Auto-detection only fires for commands that take a free-text ``query``
-    field (search, context); for qname-based commands (expand, source,
-    outline) the user can still pre-warm with explicit ``--pkg``. Run for
-    every root — multi-root projects might have separate venvs per
-    sub-project.
+    Two routing inputs:
+    - ``<pkg>: <rest>`` prefix in the free-text query field (``query`` for
+      search/context). The prefix is stripped from the query before
+      dispatch so the index sees just the actual question.
+    - ``--pkg <name>`` flag (``args.pkg``). Same effect, available on
+      every query command for cases without a free-text field.
+
+    With either input, the vendor package is built on demand (no-op when
+    already indexed). The resolved scope is attached as ``args.scope``
+    for ``QueryCommand.call`` to forward to the api function.
+
+    No prefix and no flag → ``args.scope`` stays ``None`` and the query
+    runs against the repo's own index.
     """
-    explicit = getattr(args, "pkg", None) or []
-    auto = getattr(args, "auto_vendor", True)
+    args.scope = None
+    explicit = getattr(args, "pkg", None)
     query_text = getattr(args, "query", None) or ""
-    if not explicit and (not auto or not query_text):
+    root = roots[0]  # vendor scope is single-root only (enforced at dispatch)
+
+    scope: str | None = None
+    if explicit:
+        scope = explicit
+    elif query_text:
+        prefix, stripped = parse_query_prefix(query_text, root)
+        if prefix is not None:
+            scope = prefix
+            args.query = stripped
+
+    if scope is None:
         return
-    for r in roots:
-        ensure_packages_for_query(
-            r, query_text, explicit=explicit, enable_auto=auto and bool(query_text),
-        )
+
+    if len(roots) > 1:
+        # Defer the multi-root check to dispatch time so the error path is
+        # consistent — but record the scope so QueryCommand.call surfaces it.
+        args.scope = scope
+        return
+
+    ensure_vendor_indexed(root, scope)
+    args.scope = scope
 
 
 def _vendor_dispatch(args: argparse.Namespace) -> int:
-    from snapctx.index import Index, db_path_for
-
     roots, _ = _resolve_roots(args.root)
     if not roots:
         sys.stderr.write(
@@ -375,15 +406,10 @@ def _vendor_dispatch(args: argparse.Namespace) -> int:
             f"Run a query or `snapctx index` first.\n"
         )
         return 2
-    # Vendor state is per-root; act on the closest one (single-root form).
     root = roots[0]
 
     if args.vendor_cmd == "list":
-        idx = Index(db_path_for(root))
-        try:
-            indexed = [dict(r) for r in idx.vendor_packages()]
-        finally:
-            idx.close()
+        indexed = list_indexed_vendors(root)
         available = sorted(discover_packages(root).keys())
         print(json.dumps(
             {"root": str(root), "indexed": indexed, "available": available},
@@ -392,16 +418,12 @@ def _vendor_dispatch(args: argparse.Namespace) -> int:
         return 0
 
     if args.vendor_cmd == "forget":
-        idx = Index(db_path_for(root))
-        try:
-            removed = idx.forget_vendor_package(args.name)
-        finally:
-            idx.close()
+        ok = forget_vendor(root, args.name)
         print(json.dumps(
-            {"root": str(root), "package": args.name, "files_removed": removed},
+            {"root": str(root), "package": args.name, "removed": ok},
             indent=2,
         ))
-        return 0 if removed else 1
+        return 0 if ok else 1
 
     return 2
 

--- a/src/snapctx/cli.py
+++ b/src/snapctx/cli.py
@@ -33,6 +33,7 @@ from snapctx.api import (
     search_code_multi,
 )
 from snapctx.roots import discover_roots, root_label
+from snapctx.vendor import discover_packages, ensure_packages_for_query
 from snapctx.watch import run_watch
 
 
@@ -182,6 +183,30 @@ def _refresh_indexes(roots: list[Path]) -> None:
 # ---------- argparse setup ----------
 
 
+def _add_vendor_args(p: argparse.ArgumentParser) -> None:
+    """Attach the vendor-package flags shared by every query command.
+
+    ``--pkg`` forces a specific package to be indexed (repeatable). It's
+    the escape hatch for cases where the package name doesn't appear
+    verbatim in the query but the user knows they need it (e.g. asking
+    about 'ORM' but wanting Django source).
+
+    ``--no-vendor-packages`` disables the auto-detection that scans the
+    free-text query for installed-package names. Useful when you want a
+    pure project-only result without the latency of a first-time vendor
+    ingest.
+    """
+    p.add_argument(
+        "--pkg", action="append", default=[], metavar="NAME",
+        help="Index this third-party package on demand (repeatable).",
+    )
+    p.add_argument(
+        "--no-vendor-packages", dest="auto_vendor",
+        action="store_false", default=True,
+        help="Don't auto-index packages whose name appears in the query.",
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="snapctx", description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -208,6 +233,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Ranker. hybrid = RRF of FTS5 + embeddings (default).",
     )
     p_search.add_argument("--root", default=".")
+    _add_vendor_args(p_search)
 
     p_expand = sub.add_parser("expand", help="Walk the call graph around a qname.")
     p_expand.add_argument("qname")
@@ -216,15 +242,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_expand.add_argument("--depth", type=int, default=1)
     p_expand.add_argument("--root", default=".")
+    _add_vendor_args(p_expand)
 
     p_outline = sub.add_parser("outline", help="Show the symbol tree of a file.")
     p_outline.add_argument("path")
     p_outline.add_argument("--root", default=".")
+    _add_vendor_args(p_outline)
 
     p_source = sub.add_parser("source", help="Show the source of a single symbol.")
     p_source.add_argument("qname")
     p_source.add_argument("--with-neighbors", action="store_true")
     p_source.add_argument("--root", default=".")
+    _add_vendor_args(p_source)
 
     p_context = sub.add_parser(
         "context",
@@ -244,6 +273,22 @@ def _build_parser() -> argparse.ArgumentParser:
     p_context.add_argument("--mode", choices=["lexical", "vector", "hybrid"], default="hybrid")
     p_context.add_argument("--kind", default=None)
     p_context.add_argument("--root", default=".")
+    _add_vendor_args(p_context)
+
+    p_vendor = sub.add_parser(
+        "vendor",
+        help="List or forget on-demand-indexed third-party packages.",
+    )
+    vendor_sub = p_vendor.add_subparsers(dest="vendor_cmd", required=True)
+    p_vendor_list = vendor_sub.add_parser(
+        "list", help="Show indexed vendor packages (and what's available to index)."
+    )
+    p_vendor_list.add_argument("--root", default=".")
+    p_vendor_forget = vendor_sub.add_parser(
+        "forget", help="Drop a vendor package's symbols from the index."
+    )
+    p_vendor_forget.add_argument("name")
+    p_vendor_forget.add_argument("--root", default=".")
 
     p_roots = sub.add_parser(
         "roots",
@@ -274,6 +319,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "roots":
         return _print_roots(args.root)
 
+    if args.cmd == "vendor":
+        return _vendor_dispatch(args)
+
     # Query commands: discover, ensure index is fresh, dispatch.
     roots, anchor = _resolve_roots(args.root)
     if not roots:
@@ -286,6 +334,8 @@ def main(argv: list[str] | None = None) -> int:
         # nothing changed.
         _refresh_indexes(roots)
 
+    _ensure_query_vendor_packages(roots, args)
+
     cmd = _QUERY_BY_NAME.get(args.cmd)
     if cmd is None:
         parser.error(f"unknown command: {args.cmd}")
@@ -293,6 +343,67 @@ def main(argv: list[str] | None = None) -> int:
 
     print(json.dumps(cmd.call(args, roots, anchor), indent=2))
     return 0
+
+
+def _ensure_query_vendor_packages(roots: list[Path], args: argparse.Namespace) -> None:
+    """Index vendor packages referenced by this query, if any.
+
+    Auto-detection only fires for commands that take a free-text ``query``
+    field (search, context); for qname-based commands (expand, source,
+    outline) the user can still pre-warm with explicit ``--pkg``. Run for
+    every root — multi-root projects might have separate venvs per
+    sub-project.
+    """
+    explicit = getattr(args, "pkg", None) or []
+    auto = getattr(args, "auto_vendor", True)
+    query_text = getattr(args, "query", None) or ""
+    if not explicit and (not auto or not query_text):
+        return
+    for r in roots:
+        ensure_packages_for_query(
+            r, query_text, explicit=explicit, enable_auto=auto and bool(query_text),
+        )
+
+
+def _vendor_dispatch(args: argparse.Namespace) -> int:
+    from snapctx.index import Index, db_path_for
+
+    roots, _ = _resolve_roots(args.root)
+    if not roots:
+        sys.stderr.write(
+            f"snapctx: no .snapctx/index.db reachable from {args.root}. "
+            f"Run a query or `snapctx index` first.\n"
+        )
+        return 2
+    # Vendor state is per-root; act on the closest one (single-root form).
+    root = roots[0]
+
+    if args.vendor_cmd == "list":
+        idx = Index(db_path_for(root))
+        try:
+            indexed = [dict(r) for r in idx.vendor_packages()]
+        finally:
+            idx.close()
+        available = sorted(discover_packages(root).keys())
+        print(json.dumps(
+            {"root": str(root), "indexed": indexed, "available": available},
+            indent=2,
+        ))
+        return 0
+
+    if args.vendor_cmd == "forget":
+        idx = Index(db_path_for(root))
+        try:
+            removed = idx.forget_vendor_package(args.name)
+        finally:
+            idx.close()
+        print(json.dumps(
+            {"root": str(root), "package": args.name, "files_removed": removed},
+            indent=2,
+        ))
+        return 0 if removed else 1
+
+    return 2
 
 
 def _print_roots(start: str) -> int:

--- a/src/snapctx/config.py
+++ b/src/snapctx/config.py
@@ -29,9 +29,10 @@ extra_include = ["vendor/internal-fork/**"]
 extra_exclude = ["docs/generated/**", "**/*.snapshot.tsx"]
 
 # Toggles (defaults match current behavior).
-skip_vendor_bundles = true       # filter .min.js / *-bundle.js / .map / ...
-respect_gitignore   = true       # honor the repo's .gitignore
-max_file_size       = 256000     # bytes; default 250 KiB
+skip_vendor_bundles  = true      # filter .min.js / *-bundle.js / .map / ...
+skip_vendor_packages = true      # filter node_modules / .venv / vendor / ...
+respect_gitignore    = true      # honor the repo's .gitignore
+max_file_size        = 256000    # bytes; default 250 KiB
 
 # Restrict to specific languages. Default: every parser is active.
 # Valid values: "python", "typescript".
@@ -68,6 +69,7 @@ class WalkerConfig:
     extra_include: tuple[str, ...] = ()
     extra_exclude: tuple[str, ...] = ()
     skip_vendor_bundles: bool = True
+    skip_vendor_packages: bool = True
     respect_gitignore: bool = True
     max_file_size: int = DEFAULT_MAX_FILE_SIZE
     # ``None`` = every registered parser is active. Otherwise restrict
@@ -112,6 +114,7 @@ def load_config(root: Path) -> Config:
         extra_include=_str_tuple(walker_data, "extra_include", path),
         extra_exclude=_str_tuple(walker_data, "extra_exclude", path),
         skip_vendor_bundles=_bool(walker_data, "skip_vendor_bundles", path, True),
+        skip_vendor_packages=_bool(walker_data, "skip_vendor_packages", path, True),
         respect_gitignore=_bool(walker_data, "respect_gitignore", path, True),
         max_file_size=_int(walker_data, "max_file_size", path, DEFAULT_MAX_FILE_SIZE),
         languages=_str_set_optional(walker_data, "languages", path),

--- a/src/snapctx/index.py
+++ b/src/snapctx/index.py
@@ -81,6 +81,13 @@ CREATE TABLE IF NOT EXISTS symbol_vectors (
     vector  BLOB NOT NULL,
     FOREIGN KEY (qname) REFERENCES symbols(qname) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS indexed_vendor_packages (
+    name        TEXT PRIMARY KEY,
+    path        TEXT NOT NULL,
+    indexed_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_vendor_path ON indexed_vendor_packages(path);
 """
 
 
@@ -101,6 +108,12 @@ class Index:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
+        # Manual transaction control. Python's default ``isolation_level=""``
+        # auto-begins a transaction on the first DML, which then collides
+        # with the explicit ``BEGIN`` issued by ``tx()`` ("cannot start a
+        # transaction within a transaction"). With ``None`` the only txn
+        # boundaries are the explicit BEGIN/COMMIT in ``tx()``.
+        self.conn.isolation_level = None
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA foreign_keys=ON")
         self.conn.executescript(SCHEMA)
@@ -116,19 +129,77 @@ class Index:
 
     def forget_file(self, file: str) -> None:
         """Remove all rows for a file (symbols, calls, imports, FTS, vectors, files)."""
-        cur = self.conn.cursor()
-        cur.execute(
-            "DELETE FROM symbols_fts WHERE qname IN (SELECT qname FROM symbols WHERE file = ?)",
-            (file,),
+        with self.tx():
+            cur = self.conn.cursor()
+            cur.execute(
+                "DELETE FROM symbols_fts WHERE qname IN (SELECT qname FROM symbols WHERE file = ?)",
+                (file,),
+            )
+            cur.execute(
+                "DELETE FROM symbol_vectors WHERE qname IN (SELECT qname FROM symbols WHERE file = ?)",
+                (file,),
+            )
+            cur.execute("DELETE FROM symbols WHERE file = ?", (file,))
+            cur.execute("DELETE FROM calls   WHERE file = ?", (file,))
+            cur.execute("DELETE FROM imports WHERE file = ?", (file,))
+            cur.execute("DELETE FROM files   WHERE path = ?", (file,))
+
+    def wipe_all(self) -> None:
+        """Drop every data row, keeping the schema. Used when the project
+        root has been renamed/moved and the stored absolute paths no longer
+        resolve — full rebuild is cheaper than path-rewriting."""
+        with self.tx():
+            for tbl in (
+                "symbols_fts", "symbol_vectors",
+                "symbols", "calls", "imports", "files",
+                "indexed_vendor_packages",
+            ):
+                self.conn.execute(f"DELETE FROM {tbl}")
+
+    # ---------- vendor-package tracking ----------
+
+    def is_vendor_indexed(self, name: str) -> bool:
+        return self.conn.execute(
+            "SELECT 1 FROM indexed_vendor_packages WHERE name = ?", (name,)
+        ).fetchone() is not None
+
+    def mark_vendor_indexed(self, name: str, path: str) -> None:
+        self.conn.execute(
+            "INSERT OR REPLACE INTO indexed_vendor_packages(name, path, indexed_at) "
+            "VALUES (?, ?, ?)",
+            (name, path, time.time()),
         )
-        cur.execute(
-            "DELETE FROM symbol_vectors WHERE qname IN (SELECT qname FROM symbols WHERE file = ?)",
-            (file,),
-        )
-        cur.execute("DELETE FROM symbols WHERE file = ?", (file,))
-        cur.execute("DELETE FROM calls   WHERE file = ?", (file,))
-        cur.execute("DELETE FROM imports WHERE file = ?", (file,))
-        cur.execute("DELETE FROM files   WHERE path = ?", (file,))
+
+    def vendor_packages(self) -> list[sqlite3.Row]:
+        return self.conn.execute(
+            "SELECT name, path, indexed_at FROM indexed_vendor_packages "
+            "ORDER BY name ASC"
+        ).fetchall()
+
+    def vendor_paths(self) -> list[str]:
+        return [row["path"] for row in self.conn.execute(
+            "SELECT path FROM indexed_vendor_packages"
+        ).fetchall()]
+
+    def forget_vendor_package(self, name: str) -> int:
+        """Drop a vendor package's marker and all symbol/call/import rows
+        for files under it. Returns the number of files removed."""
+        row = self.conn.execute(
+            "SELECT path FROM indexed_vendor_packages WHERE name = ?", (name,)
+        ).fetchone()
+        if row is None:
+            return 0
+        path_prefix = row["path"].rstrip("/") + "/"
+        with self.tx():
+            files = [r["path"] for r in self.conn.execute(
+                "SELECT path FROM files WHERE path LIKE ? || '%'", (path_prefix,)
+            ).fetchall()]
+            for f in files:
+                self.forget_file(f)
+            self.conn.execute(
+                "DELETE FROM indexed_vendor_packages WHERE name = ?", (name,)
+            )
+        return len(files)
 
     # ---------- ingest ----------
 
@@ -266,10 +337,10 @@ class Index:
         rows = [
             (q, np.asarray(v, dtype=np.float32).tobytes()) for q, v in zip(qnames, vectors)
         ]
-        self.conn.executemany(
-            "INSERT OR REPLACE INTO symbol_vectors(qname, vector) VALUES (?, ?)", rows
-        )
-        self.conn.commit()
+        with self.tx():
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO symbol_vectors(qname, vector) VALUES (?, ?)", rows
+            )
 
     def vector_search(
         self, query_vec, limit: int, kind: str | None = None
@@ -378,18 +449,27 @@ class Index:
         (e.g. Mixin.method via MRO; Django-ORM chains like Model:objects.filter),
         and this sweep removes the ones that didn't pan out.
         """
-        cur = self.conn.execute(
-            "UPDATE calls SET callee_qname = NULL "
-            "WHERE callee_qname IS NOT NULL "
-            "  AND callee_qname NOT IN (SELECT qname FROM symbols)"
-        )
-        self.conn.commit()
-        return cur.rowcount
+        with self.tx():
+            cur = self.conn.execute(
+                "UPDATE calls SET callee_qname = NULL "
+                "WHERE callee_qname IS NOT NULL "
+                "  AND callee_qname NOT IN (SELECT qname FROM symbols)"
+            )
+            return cur.rowcount
 
     # ---------- transaction helper ----------
 
     @contextmanager
     def tx(self) -> Iterator[None]:
+        """Open a transaction, or join the caller's if one is already open.
+
+        Reentrancy lets composite ops (e.g. ``ingest`` calls ``forget_file``)
+        each wrap themselves in ``tx()`` for safety when called standalone,
+        without nesting ``BEGIN``/``COMMIT`` when called from another tx.
+        """
+        if self.conn.in_transaction:
+            yield
+            return
         try:
             self.conn.execute("BEGIN")
             yield

--- a/src/snapctx/index.py
+++ b/src/snapctx/index.py
@@ -280,6 +280,19 @@ class Index:
             (callee_qname,),
         ).fetchall()
 
+    def imports_for_file(self, file: str) -> list[sqlite3.Row]:
+        """Return all imports declared in a file, ordered by line.
+
+        Used by cross-package call resolution: when a call's callee is
+        unresolved, we look at what the file imports to figure out which
+        sibling vendor index might know the target.
+        """
+        return self.conn.execute(
+            "SELECT module, name, alias, line FROM imports "
+            "WHERE file = ? ORDER BY line ASC",
+            (file,),
+        ).fetchall()
+
     # ---------- vector store ----------
 
     def symbols_without_vectors(self) -> list[sqlite3.Row]:

--- a/src/snapctx/index.py
+++ b/src/snapctx/index.py
@@ -81,13 +81,6 @@ CREATE TABLE IF NOT EXISTS symbol_vectors (
     vector  BLOB NOT NULL,
     FOREIGN KEY (qname) REFERENCES symbols(qname) ON DELETE CASCADE
 );
-
-CREATE TABLE IF NOT EXISTS indexed_vendor_packages (
-    name        TEXT PRIMARY KEY,
-    path        TEXT NOT NULL,
-    indexed_at  REAL NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_vendor_path ON indexed_vendor_packages(path);
 """
 
 
@@ -95,9 +88,19 @@ def sha_bytes(data: bytes) -> str:
     return hashlib.sha1(data).hexdigest()
 
 
-def db_path_for(root: Path) -> Path:
-    """Resolve the standard SQLite path for a repo root."""
-    return (root / ".snapctx" / "index.db").resolve()
+def db_path_for(root: Path, scope: str | None = None) -> Path:
+    """Resolve the SQLite index path for a root.
+
+    ``scope=None`` (default) returns the repo's own index. A non-None
+    scope (a package directory name like ``"django"``) returns that
+    package's isolated index. Per-package isolation keeps vector
+    neighborhoods focused — a search for ``QuerySet`` inside the
+    django scope can't be polluted by the user's own filter classes,
+    and vice versa.
+    """
+    if scope is None:
+        return (root / ".snapctx" / "index.db").resolve()
+    return (root / ".snapctx" / "vendor" / scope / "index.db").resolve()
 
 
 class Index:
@@ -152,54 +155,8 @@ class Index:
             for tbl in (
                 "symbols_fts", "symbol_vectors",
                 "symbols", "calls", "imports", "files",
-                "indexed_vendor_packages",
             ):
                 self.conn.execute(f"DELETE FROM {tbl}")
-
-    # ---------- vendor-package tracking ----------
-
-    def is_vendor_indexed(self, name: str) -> bool:
-        return self.conn.execute(
-            "SELECT 1 FROM indexed_vendor_packages WHERE name = ?", (name,)
-        ).fetchone() is not None
-
-    def mark_vendor_indexed(self, name: str, path: str) -> None:
-        self.conn.execute(
-            "INSERT OR REPLACE INTO indexed_vendor_packages(name, path, indexed_at) "
-            "VALUES (?, ?, ?)",
-            (name, path, time.time()),
-        )
-
-    def vendor_packages(self) -> list[sqlite3.Row]:
-        return self.conn.execute(
-            "SELECT name, path, indexed_at FROM indexed_vendor_packages "
-            "ORDER BY name ASC"
-        ).fetchall()
-
-    def vendor_paths(self) -> list[str]:
-        return [row["path"] for row in self.conn.execute(
-            "SELECT path FROM indexed_vendor_packages"
-        ).fetchall()]
-
-    def forget_vendor_package(self, name: str) -> int:
-        """Drop a vendor package's marker and all symbol/call/import rows
-        for files under it. Returns the number of files removed."""
-        row = self.conn.execute(
-            "SELECT path FROM indexed_vendor_packages WHERE name = ?", (name,)
-        ).fetchone()
-        if row is None:
-            return 0
-        path_prefix = row["path"].rstrip("/") + "/"
-        with self.tx():
-            files = [r["path"] for r in self.conn.execute(
-                "SELECT path FROM files WHERE path LIKE ? || '%'", (path_prefix,)
-            ).fetchall()]
-            for f in files:
-                self.forget_file(f)
-            self.conn.execute(
-                "DELETE FROM indexed_vendor_packages WHERE name = ?", (name,)
-            )
-        return len(files)
 
     # ---------- ingest ----------
 

--- a/src/snapctx/vendor.py
+++ b/src/snapctx/vendor.py
@@ -1,0 +1,157 @@
+"""Query-driven on-demand indexing of installed third-party packages.
+
+The user shouldn't have to remember to run ``snapctx index`` after switching
+to a question about Django internals. This module hooks into the query
+path: tokenize the user's query, match tokens against package directories
+discovered under the project root, and ingest just those packages on the
+fly. Indexed packages are tracked in ``indexed_vendor_packages`` so the
+second query for the same package is zero-cost.
+
+Discovery is intentionally narrow:
+
+- Python: ``<root>/{.venv,venv,env}/lib/python*/site-packages/<name>/``
+- Node:   ``<root>/node_modules/<name>/`` (top-level; scoped ``@x/y``
+  packages are intentionally out of scope for v1 — they're a small
+  fraction of usage and complicate query matching).
+
+We match query tokens against the *directory name* (which is also the
+import name in 99% of cases), not the distribution name from PyPI / npm.
+That avoids needing metadata and matches what the user types.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_VENV_DIRS = (".venv", "venv", "env")
+_DIST_INFO_SUFFIXES = (".dist-info", ".egg-info", ".data")
+_NODE_MODULES = "node_modules"
+
+
+def discover_packages(root: Path) -> dict[str, Path]:
+    """Return ``{name: absolute_path}`` for installed packages under ``root``.
+
+    First match wins on duplicates so a project's primary venv (``.venv``,
+    checked first) shadows any stale ``venv/`` left over from a previous
+    setup. Caller is expected to filter by query relevance — discovery is
+    cheap (one ``glob`` per known location).
+    """
+    found: dict[str, Path] = {}
+    root = root.resolve()
+
+    for venv_name in _VENV_DIRS:
+        venv = root / venv_name
+        if not venv.is_dir():
+            continue
+        for site in venv.glob("lib/python*/site-packages"):
+            if not site.is_dir():
+                continue
+            for child in site.iterdir():
+                name = child.name
+                if not child.is_dir():
+                    continue
+                if name.startswith((".", "_")):
+                    continue
+                if any(name.endswith(suf) for suf in _DIST_INFO_SUFFIXES):
+                    continue
+                if name not in found:
+                    found[name] = child.resolve()
+
+    nm = root / _NODE_MODULES
+    if nm.is_dir():
+        for child in nm.iterdir():
+            if not child.is_dir():
+                continue
+            name = child.name
+            if name.startswith((".", "@")):
+                continue
+            if name not in found:
+                found[name] = child.resolve()
+
+    return found
+
+
+_TOKEN_SPLIT = re.compile(r"[^\w]+")
+
+
+def query_tokens(query: str) -> set[str]:
+    """Lowercased, word-boundary-split tokens from a free-text query."""
+    return {t for t in _TOKEN_SPLIT.split(query.lower()) if t}
+
+
+def match_packages(query: str, packages: dict[str, Path]) -> list[tuple[str, Path]]:
+    """Return ``(name, path)`` pairs for packages whose name appears as a
+    full token in the query. Case-insensitive, exact token match — no
+    fuzzy / substring hits, since "modeling" should not pull in ``model``.
+    """
+    tokens = query_tokens(query)
+    if not tokens:
+        return []
+    return [(name, path) for name, path in packages.items() if name.lower() in tokens]
+
+
+def ensure_packages_for_query(
+    root: Path,
+    query: str,
+    *,
+    explicit: list[str] | None = None,
+    enable_auto: bool = True,
+) -> list[dict]:
+    """Index any vendor packages referenced by the query that aren't yet indexed.
+
+    ``explicit`` is a user-provided list (CLI ``--pkg``) that bypasses the
+    token-match. Auto-detection runs only when ``enable_auto`` is True.
+
+    Returns one summary dict per *newly-indexed* package; already-indexed
+    packages are silently skipped (they're still queryable). Progress is
+    written to stderr so JSON callers stay clean.
+    """
+    from snapctx.api._indexer import index_subtree
+    from snapctx.index import Index, db_path_for
+
+    targets: list[tuple[str, Path]] = []
+    packages = discover_packages(root)
+    if explicit:
+        for name in explicit:
+            if name in packages:
+                targets.append((name, packages[name]))
+            else:
+                sys.stderr.write(
+                    f"snapctx: --pkg {name} not found under {root} "
+                    f"(checked .venv/, venv/, env/, node_modules/)\n"
+                )
+    if enable_auto:
+        for pair in match_packages(query, packages):
+            if pair not in targets:
+                targets.append(pair)
+
+    if not targets:
+        return []
+
+    idx = Index(db_path_for(root))
+    try:
+        pending = [(n, p) for n, p in targets if not idx.is_vendor_indexed(n)]
+    finally:
+        idx.close()
+
+    summaries: list[dict] = []
+    for name, path in pending:
+        sys.stderr.write(
+            f"snapctx: indexing vendor package {name} at {path} (one-time)...\n"
+        )
+        summary = index_subtree(root, path)
+        summary["package"] = name
+        summaries.append(summary)
+        # Mark as indexed in a fresh connection (index_subtree closed its own).
+        idx = Index(db_path_for(root))
+        try:
+            idx.mark_vendor_indexed(name, str(path))
+        finally:
+            idx.close()
+        sys.stderr.write(
+            f"snapctx: vendor package {name} ready "
+            f"({summary['files_updated']} files, {summary['symbols_indexed']} symbols).\n"
+        )
+    return summaries

--- a/src/snapctx/vendor.py
+++ b/src/snapctx/vendor.py
@@ -1,22 +1,28 @@
-"""Query-driven on-demand indexing of installed third-party packages.
+"""Per-package on-demand indexing of installed third-party packages.
 
-The user shouldn't have to remember to run ``snapctx index`` after switching
-to a question about Django internals. This module hooks into the query
-path: tokenize the user's query, match tokens against package directories
-discovered under the project root, and ingest just those packages on the
-fly. Indexed packages are tracked in ``indexed_vendor_packages`` so the
-second query for the same package is zero-cost.
+Each indexed package gets its own isolated SQLite database under
+``<root>/.snapctx/vendor/<name>/index.db``. Two reasons for the per-
+package isolation rather than merging into the repo's index:
 
-Discovery is intentionally narrow:
+1. **Vector neighborhood quality.** Cosine search over a single
+   coherent corpus (just Django source) returns much sharper matches
+   than over a mixed corpus (Django + the user's filter classes that
+   share vocabulary). The merged form noticeably degrades retrieval.
+2. **Cleaner qnames.** Inside the package's index we re-root the
+   parser at the package directory itself, so qnames look like
+   ``db.models.query:QuerySet`` — Django's actual module structure —
+   not ``.venv.lib.python3.14.site-packages.django.db.models.query:QuerySet``.
 
+Routing is explicit. The user prefixes a query with ``<pkg>: <rest>``
+(e.g. ``"django: queryset filter chain"``) and snapctx routes to that
+package's index. No prefix → repo only. There is no implicit auto-
+detection from arbitrary query tokens — that was the cause of the
+original cross-namespace noise.
+
+Discovery scans:
 - Python: ``<root>/{.venv,venv,env}/lib/python*/site-packages/<name>/``
-- Node:   ``<root>/node_modules/<name>/`` (top-level; scoped ``@x/y``
-  packages are intentionally out of scope for v1 — they're a small
-  fraction of usage and complicate query matching).
-
-We match query tokens against the *directory name* (which is also the
-import name in 99% of cases), not the distribution name from PyPI / npm.
-That avoids needing metadata and matches what the user types.
+- Node:   ``<root>/node_modules/<name>/`` (top-level; scoped @x/y out
+  of scope for v1)
 """
 
 from __future__ import annotations
@@ -31,13 +37,7 @@ _NODE_MODULES = "node_modules"
 
 
 def discover_packages(root: Path) -> dict[str, Path]:
-    """Return ``{name: absolute_path}`` for installed packages under ``root``.
-
-    First match wins on duplicates so a project's primary venv (``.venv``,
-    checked first) shadows any stale ``venv/`` left over from a previous
-    setup. Caller is expected to filter by query relevance — discovery is
-    cheap (one ``glob`` per known location).
-    """
+    """Return ``{name: absolute_path}`` for installed packages under ``root``."""
     found: dict[str, Path] = {}
     root = root.resolve()
 
@@ -73,85 +73,98 @@ def discover_packages(root: Path) -> dict[str, Path]:
     return found
 
 
-_TOKEN_SPLIT = re.compile(r"[^\w]+")
+_IDENTIFIER = re.compile(r"^[A-Za-z_][\w\-]*$")
 
 
-def query_tokens(query: str) -> set[str]:
-    """Lowercased, word-boundary-split tokens from a free-text query."""
-    return {t for t in _TOKEN_SPLIT.split(query.lower()) if t}
+def parse_query_prefix(query: str, root: Path) -> tuple[str | None, str]:
+    """Split ``"django: queryset filter"`` into ``("django", "queryset filter")``.
 
+    The prefix is recognized only when:
+    1. There's a single colon-separated head before the rest of the query,
+    2. the head is a single identifier (letters, digits, underscore, hyphen),
+       so we don't false-positive on dotted qnames like
+       ``django.db.models:QuerySet``,
+    3. the head matches a directory name discovered under ``root``'s
+       installed packages — *or* a directory under ``.snapctx/vendor/``
+       (already-indexed package, even if the source has since been
+       deleted).
 
-def match_packages(query: str, packages: dict[str, Path]) -> list[tuple[str, Path]]:
-    """Return ``(name, path)`` pairs for packages whose name appears as a
-    full token in the query. Case-insensitive, exact token match — no
-    fuzzy / substring hits, since "modeling" should not pull in ``model``.
+    Returns ``(None, original_query)`` when the prefix doesn't qualify so
+    the caller falls back to repo-only routing.
     """
-    tokens = query_tokens(query)
-    if not tokens:
+    if ":" not in query:
+        return None, query
+    head, rest = query.split(":", 1)
+    head_clean = head.strip()
+    if not _IDENTIFIER.match(head_clean):
+        return None, query
+    known = set(discover_packages(root)) | set(list_indexed_vendors(root))
+    if head_clean not in known:
+        # A name like ``foo:bar`` where ``foo`` isn't a package is
+        # almost certainly a qname and should pass through unchanged.
+        return None, query
+    return head_clean, rest.strip()
+
+
+def vendor_index_dir(root: Path, name: str) -> Path:
+    """``<root>/.snapctx/vendor/<name>/`` — the per-package storage dir."""
+    return (root / ".snapctx" / "vendor" / name).resolve()
+
+
+def list_indexed_vendors(root: Path) -> list[str]:
+    """Names of packages with an existing per-package index."""
+    base = root / ".snapctx" / "vendor"
+    if not base.is_dir():
         return []
-    return [(name, path) for name, path in packages.items() if name.lower() in tokens]
+    return sorted(
+        d.name for d in base.iterdir()
+        if d.is_dir() and (d / "index.db").exists()
+    )
 
 
-def ensure_packages_for_query(
-    root: Path,
-    query: str,
-    *,
-    explicit: list[str] | None = None,
-    enable_auto: bool = True,
-) -> list[dict]:
-    """Index any vendor packages referenced by the query that aren't yet indexed.
+def is_vendor_indexed(root: Path, name: str) -> bool:
+    return (vendor_index_dir(root, name) / "index.db").exists()
 
-    ``explicit`` is a user-provided list (CLI ``--pkg``) that bypasses the
-    token-match. Auto-detection runs only when ``enable_auto`` is True.
 
-    Returns one summary dict per *newly-indexed* package; already-indexed
-    packages are silently skipped (they're still queryable). Progress is
-    written to stderr so JSON callers stay clean.
+def ensure_vendor_indexed(
+    root: Path, name: str, *, force: bool = False
+) -> dict | None:
+    """Build (or refresh) the per-package index for ``name`` under ``root``.
+
+    Returns the indexer summary, or ``None`` when the package is unknown
+    (not installed under any discovered venv / node_modules) and we have
+    nothing to index. Existing indexes are skipped unless ``force=True``.
     """
-    from snapctx.api._indexer import index_subtree
-    from snapctx.index import Index, db_path_for
+    if not force and is_vendor_indexed(root, name):
+        return None
 
-    targets: list[tuple[str, Path]] = []
     packages = discover_packages(root)
-    if explicit:
-        for name in explicit:
-            if name in packages:
-                targets.append((name, packages[name]))
-            else:
-                sys.stderr.write(
-                    f"snapctx: --pkg {name} not found under {root} "
-                    f"(checked .venv/, venv/, env/, node_modules/)\n"
-                )
-    if enable_auto:
-        for pair in match_packages(query, packages):
-            if pair not in targets:
-                targets.append(pair)
-
-    if not targets:
-        return []
-
-    idx = Index(db_path_for(root))
-    try:
-        pending = [(n, p) for n, p in targets if not idx.is_vendor_indexed(n)]
-    finally:
-        idx.close()
-
-    summaries: list[dict] = []
-    for name, path in pending:
+    pkg_path = packages.get(name)
+    if pkg_path is None:
         sys.stderr.write(
-            f"snapctx: indexing vendor package {name} at {path} (one-time)...\n"
+            f"snapctx: package {name!r} not found under {root} "
+            f"(checked .venv/, venv/, env/, node_modules/)\n"
         )
-        summary = index_subtree(root, path)
-        summary["package"] = name
-        summaries.append(summary)
-        # Mark as indexed in a fresh connection (index_subtree closed its own).
-        idx = Index(db_path_for(root))
-        try:
-            idx.mark_vendor_indexed(name, str(path))
-        finally:
-            idx.close()
-        sys.stderr.write(
-            f"snapctx: vendor package {name} ready "
-            f"({summary['files_updated']} files, {summary['symbols_indexed']} symbols).\n"
-        )
-    return summaries
+        return None
+
+    sys.stderr.write(
+        f"snapctx: indexing vendor package {name} at {pkg_path} (one-time)...\n"
+    )
+    from snapctx.api._indexer import index_vendor_package
+    summary = index_vendor_package(root, name, pkg_path)
+    sys.stderr.write(
+        f"snapctx: vendor package {name} ready "
+        f"({summary['files_updated']} files, {summary['symbols_indexed']} symbols).\n"
+    )
+    return summary
+
+
+def forget_vendor(root: Path, name: str) -> bool:
+    """Delete a package's per-package index directory. Returns True if removed."""
+    import shutil
+
+    d = vendor_index_dir(root, name)
+    if not d.is_dir():
+        return False
+    shutil.rmtree(d)
+    return True

--- a/src/snapctx/walker.py
+++ b/src/snapctx/walker.py
@@ -16,11 +16,19 @@ from snapctx.parsers.registry import (
 
 ALWAYS_SKIP = {
     ".git", ".hg", ".svn",
-    ".venv", "venv", "env",
-    "node_modules", "bower_components", "vendor",
     "__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache",
     "dist", "build", ".tox",
     ".snapctx",
+}
+
+# Third-party-dependency directories. Skipped by default because they are
+# not the user's code and a single ``node_modules`` tree can dwarf the
+# repo's real source by 100×. Toggleable via
+# ``[walker].skip_vendor_packages = false`` for the rare case where you
+# genuinely need to search inside deps (e.g. debugging an upstream bug).
+VENDOR_PACKAGE_DIRS = {
+    ".venv", "venv", "env",
+    "node_modules", "bower_components", "vendor",
 }
 
 # Filename suffixes that indicate bundled/minified third-party code. Parsing
@@ -34,6 +42,20 @@ _VENDOR_BUNDLE_SUFFIXES = (
     "-bundle.js", "-bundle.mjs",              # e.g. swagger-ui-bundle.js
     ".standalone.js", ".lib.js",              # e.g. redoc.standalone.js
 )
+
+
+def skip_dirs_for(cfg: WalkerConfig) -> set[str]:
+    """Return the set of directory names to skip given a walker config.
+
+    Centralizes the union of ``ALWAYS_SKIP``, vendor-package dirs (when
+    enabled), and the user's ``extra_skip_dirs`` so the walker and the
+    watcher (which both need to know "is this path under a skipped dir?")
+    stay in sync as the rules evolve.
+    """
+    skip = ALWAYS_SKIP | set(cfg.extra_skip_dirs)
+    if cfg.skip_vendor_packages:
+        skip |= VENDOR_PACKAGE_DIRS
+    return skip
 
 
 def load_gitignore(root: Path) -> pathspec.PathSpec:
@@ -60,7 +82,7 @@ def iter_source_files(
     cfg = config or WalkerConfig()
     root = root.resolve()
 
-    skip_dirs = ALWAYS_SKIP | set(cfg.extra_skip_dirs)
+    skip_dirs = skip_dirs_for(cfg)
     skip_suffixes = (
         _VENDOR_BUNDLE_SUFFIXES + cfg.extra_skip_suffixes
         if cfg.skip_vendor_bundles

--- a/src/snapctx/watch.py
+++ b/src/snapctx/watch.py
@@ -6,7 +6,8 @@ Design:
 - Events are debounced: rapid bursts (e.g. a git checkout that touches 200
   files) coalesce into a single re-index after the dust settles.
 - Only events inside the supported extension set and outside the
-  ``ALWAYS_SKIP`` directory list trigger a re-index.
+  walker's skip-dir set (``ALWAYS_SKIP`` plus vendor-package dirs when
+  ``skip_vendor_packages`` is on) trigger a re-index.
 - ``index_root`` is already incremental, so a trigger re-parses only the
   files whose SHA changed — typically <500 ms.
 
@@ -28,7 +29,7 @@ from watchdog.observers import Observer
 from snapctx.api import index_root
 from snapctx.config import load_config
 from snapctx.parsers.registry import extensions_for_languages, supported_extensions
-from snapctx.walker import ALWAYS_SKIP
+from snapctx.walker import skip_dirs_for
 
 
 class _IndexHandler(FileSystemEventHandler):
@@ -54,7 +55,7 @@ class _IndexHandler(FileSystemEventHandler):
             if cfg.walker.languages is not None
             else supported_extensions()
         )
-        self._skip_dirs = ALWAYS_SKIP | set(cfg.walker.extra_skip_dirs)
+        self._skip_dirs = skip_dirs_for(cfg.walker)
 
     def on_any_event(self, event: FileSystemEvent) -> None:
         if event.is_directory:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ def test_no_config_returns_defaults(tmp_path: Path) -> None:
     cfg = load_config(tmp_path)
     assert cfg == Config.default()
     assert cfg.walker.skip_vendor_bundles is True
+    assert cfg.walker.skip_vendor_packages is True
     assert cfg.walker.respect_gitignore is True
     assert cfg.walker.languages is None
 
@@ -68,6 +69,34 @@ def test_default_skip_vendor_bundles_drops_minified(tmp_path: Path) -> None:
 
     files = {p.name for p in iter_source_files(tmp_path)}
     assert files == {"real.js"}
+
+
+def test_default_skips_vendor_package_dirs(tmp_path: Path) -> None:
+    """Default behavior: ``node_modules`` / ``.venv`` / ``vendor`` stay out of the index."""
+    (tmp_path / "app.py").write_text("def x(): pass\n")
+    (tmp_path / "node_modules" / "lib").mkdir(parents=True)
+    (tmp_path / "node_modules" / "lib" / "dep.js").write_text("export const x = 1;\n")
+    (tmp_path / ".venv" / "lib").mkdir(parents=True)
+    (tmp_path / ".venv" / "lib" / "site.py").write_text("def y(): pass\n")
+    (tmp_path / "vendor" / "fork").mkdir(parents=True)
+    (tmp_path / "vendor" / "fork" / "patched.py").write_text("def z(): pass\n")
+
+    files = {p.name for p in iter_source_files(tmp_path)}
+    assert files == {"app.py"}
+
+
+def test_skip_vendor_packages_off_indexes_node_modules(tmp_path: Path) -> None:
+    """Toggle off: deps under ``node_modules`` / ``vendor`` become indexable and queryable."""
+    (tmp_path / "app.py").write_text("def x(): pass\n")
+    (tmp_path / "node_modules" / "lib").mkdir(parents=True)
+    (tmp_path / "node_modules" / "lib" / "dep.js").write_text("export const x = 1;\n")
+    (tmp_path / "vendor" / "fork").mkdir(parents=True)
+    (tmp_path / "vendor" / "fork" / "patched.py").write_text("def z(): pass\n")
+
+    _write_config(tmp_path, '[walker]\nskip_vendor_packages = false\n')
+    cfg = load_config(tmp_path)
+    files = {p.name for p in iter_source_files(tmp_path, cfg.walker)}
+    assert files == {"app.py", "dep.js", "patched.py"}
 
 
 def test_max_file_size_override(tmp_path: Path) -> None:
@@ -126,10 +155,9 @@ def test_extra_include_overrides_gitignore(tmp_path: Path) -> None:
     (tmp_path / "vendor" / "junk").mkdir()
     (tmp_path / "vendor" / "junk" / "raw.py").write_text("def y(): pass\n")
 
-    # Without the override, vendor/ is hidden by .gitignore AND by the
-    # ALWAYS_SKIP "vendor" entry. We can override the gitignore but not
-    # ALWAYS_SKIP without renaming the dir — verify the include works
-    # against a plain .gitignore-only case.
+    # vendor/ is hidden by both .gitignore and VENDOR_PACKAGE_DIRS, and
+    # extra_include only overrides the gitignore layer — fall back to a
+    # plain gitignore-only case so the test isolates the include behavior.
     (tmp_path / "private").mkdir()
     (tmp_path / "private" / "internal.py").write_text("def z(): pass\n")
     (tmp_path / ".gitignore").write_text("private/\n")

--- a/tests/test_cross_package.py
+++ b/tests/test_cross_package.py
@@ -1,0 +1,216 @@
+"""Cross-package call resolution: when a call inside one vendor package's
+index lands on a name imported from another *also-indexed* package, the
+graph stitches across the two indexes.
+
+Honors the explicit-prefix rule from the routing redesign: cross-resolution
+only peeks into packages the user has *already chosen* to index. Sibling
+packages without an index stay unresolved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from snapctx.api import context, expand, index_root
+from snapctx.api._cross_package import CrossPackageResolver, _candidate_qnames
+from snapctx.vendor import ensure_vendor_indexed
+
+
+def _make_python_pkg(root: Path, name: str, files: dict[str, str]) -> Path:
+    """Create a fake site-packages package with the given files."""
+    site = root / ".venv" / "lib" / "python3.14" / "site-packages"
+    pkg = site / name
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    for relpath, body in files.items():
+        target = pkg / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    return pkg
+
+
+# ---------- candidate qname enumeration ----------
+
+
+def test_candidate_qnames_simple_function() -> None:
+    """``from x.y import z`` then ``z(...)``: in_pkg_module=y, chain=[z]."""
+    cands = _candidate_qnames("y", ["z"])
+    assert "y:z" in cands
+
+
+def test_candidate_qnames_submodule_via_from_import() -> None:
+    """``from x import y`` then ``y.z(...)``: chain=[y, z], in_pkg_module=''."""
+    cands = _candidate_qnames("", ["y", "z"])
+    assert "y:z" in cands
+
+
+def test_candidate_qnames_class_method() -> None:
+    """``from x.y import C`` then ``C.method(...)``: chain=[C, method]."""
+    cands = _candidate_qnames("y", ["C", "method"])
+    # Either "y:C.method" (C is a class in y.py) or "y.C:method" — both
+    # are tried so a class-with-method or a sub-sub-module both resolve.
+    assert "y:C.method" in cands
+    assert "y.C:method" in cands
+
+
+# ---------- end-to-end cross-package resolution ----------
+
+
+def test_expand_resolves_cross_package_callee(tmp_path: Path) -> None:
+    """A method in package ``alpha`` calls a function imported from package
+    ``beta``; both are indexed; ``expand`` should report the resolved
+    cross-package neighbor with a ``package`` tag."""
+    _make_python_pkg(tmp_path, "beta", {
+        "core.py": "def do_work(x): return x + 1\n",
+    })
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from beta.core import do_work\n"
+            "\n"
+            "class Worker:\n"
+            "    def run(self):\n"
+            "        return do_work(42)\n"
+        ),
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    ensure_vendor_indexed(tmp_path, "beta")
+
+    out = expand("main:Worker.run", direction="callees", root=tmp_path, scope="alpha")
+    layer0 = out["layers"][0]
+    cross_edges = [e for e in layer0 if e.get("package") == "beta"]
+    assert len(cross_edges) == 1
+    assert cross_edges[0]["qname"].endswith("core:do_work")
+
+
+def test_expand_leaves_unresolved_when_other_package_not_indexed(
+    tmp_path: Path,
+) -> None:
+    """Honors the prefix-explicit rule: don't fan out into packages the
+    user hasn't asked for. ``beta`` is installed but not indexed → the
+    cross-package call stays unresolved."""
+    _make_python_pkg(tmp_path, "beta", {
+        "core.py": "def do_work(x): return x + 1\n",
+    })
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from beta.core import do_work\n"
+            "def caller(): return do_work(1)\n"
+        ),
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    # Note: beta is NOT indexed.
+
+    out = expand("main:caller", direction="callees", root=tmp_path, scope="alpha")
+    layer0 = out["layers"][0]
+    # The do_work call should appear unresolved — no package tag, no row.
+    do_work_edges = [
+        e for e in layer0
+        if "do_work" in e.get("qname", "") or e.get("resolved") is False
+    ]
+    assert any(e.get("resolved") is False for e in do_work_edges), do_work_edges
+
+
+def test_context_includes_cross_package_callee(tmp_path: Path) -> None:
+    """``context()`` should also surface cross-package edges via
+    ``collect_neighbors``."""
+    _make_python_pkg(tmp_path, "beta", {
+        "core.py": "def do_work(x): return x + 1\n",
+    })
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from beta.core import do_work\n"
+            "def runner(): return do_work(7)\n"
+        ),
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    ensure_vendor_indexed(tmp_path, "beta")
+
+    res = context("main:runner", root=tmp_path, scope="alpha")
+    seeds = res["seeds"]
+    assert len(seeds) == 1
+    callees = seeds[0].get("callees", [])
+    cross = [c for c in callees if c.get("package") == "beta"]
+    assert len(cross) == 1
+    assert cross[0]["qname"].endswith("core:do_work")
+
+
+def test_aliased_import_resolves(tmp_path: Path) -> None:
+    """``from beta.core import do_work as dw`` then ``dw(...)``."""
+    _make_python_pkg(tmp_path, "beta", {
+        "core.py": "def do_work(x): return x + 1\n",
+    })
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from beta.core import do_work as dw\n"
+            "def caller(): return dw(1)\n"
+        ),
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    ensure_vendor_indexed(tmp_path, "beta")
+
+    out = expand("main:caller", direction="callees", root=tmp_path, scope="alpha")
+    cross = [e for e in out["layers"][0] if e.get("package") == "beta"]
+    assert len(cross) == 1
+    assert cross[0]["qname"].endswith("core:do_work")
+
+
+def test_dotted_module_import_resolves(tmp_path: Path) -> None:
+    """``from beta import core`` then ``core.do_work(...)``."""
+    _make_python_pkg(tmp_path, "beta", {
+        "core.py": "def do_work(x): return x + 1\n",
+    })
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from beta import core\n"
+            "def caller(): return core.do_work(1)\n"
+        ),
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    ensure_vendor_indexed(tmp_path, "beta")
+
+    out = expand("main:caller", direction="callees", root=tmp_path, scope="alpha")
+    cross = [e for e in out["layers"][0] if e.get("package") == "beta"]
+    assert len(cross) == 1
+    assert cross[0]["qname"].endswith("core:do_work")
+
+
+def test_resolver_does_not_recurse_into_own_index(tmp_path: Path) -> None:
+    """A package's own intra-package calls should resolve via the normal
+    parser path, not via the cross-package resolver. Verify by checking
+    that the resolver returns None for the current scope."""
+    _make_python_pkg(tmp_path, "alpha", {
+        "main.py": (
+            "from alpha.helper import helper\n"
+            "def caller(): return helper(1)\n"
+        ),
+        "helper.py": "def helper(x): return x\n",
+    })
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+
+    from snapctx.api._common import open_index
+    idx = open_index(tmp_path, scope="alpha")
+    try:
+        resolver = CrossPackageResolver(tmp_path, current_scope="alpha")
+        try:
+            # Force a resolve attempt for a name imported from alpha itself.
+            # Even if the parser missed it, the resolver should refuse to
+            # peek into its own scope.
+            file_path = str((tmp_path / ".venv/lib/python3.14/site-packages/alpha/main.py").resolve())
+            result = resolver.resolve("helper", file_path, idx)
+            assert result is None
+        finally:
+            resolver.close()
+    finally:
+        idx.close()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -45,6 +45,52 @@ def test_edit_reparses_only_changed_file(tmp_path: Path) -> None:
     assert "b:beta" in b_syms and "b:delta" in b_syms
 
 
+def test_delete_and_add_in_same_pass_does_not_raise(tmp_path: Path) -> None:
+    """Regression: forgetting a stale file then ingesting a new one in the
+    same ``index_root`` pass used to raise ``OperationalError: cannot start
+    a transaction within a transaction`` because ``forget_file`` left an
+    auto-begun txn open and ``ingest`` then issued an explicit ``BEGIN``.
+    """
+    root = tmp_path / "repo"
+    _write_repo(root)
+    index_root(root)
+
+    # Delete one file (forces forget_file) AND add one (forces ingest)
+    # in the same incremental pass.
+    (root / "c.py").unlink()
+    (root / "d.py").write_text("def delta(): return 4\n")
+    summary = index_root(root)
+    assert summary["files_removed"] == 1
+    assert summary["files_updated"] == 1
+
+
+def test_root_rename_wipes_and_rebuilds(tmp_path: Path) -> None:
+    """Regression: moving the project on disk left every absolute path in
+    the index pointing at the old location. ``index_root`` now detects the
+    mismatch and wipes the index so the rebuild repopulates with current
+    paths."""
+    import shutil
+
+    original = tmp_path / "old-name"
+    _write_repo(original)
+    index_root(original)
+
+    # Simulate ``mv old-name new-name`` (incl. the ``.snapctx/`` dir).
+    moved = tmp_path / "new-name"
+    shutil.move(str(original), str(moved))
+
+    summary = index_root(moved)
+    assert summary["root_moved"] is True
+    # Wipe-then-rebuild: every file is "updated" (re-parsed), nothing is
+    # "removed" (the wipe happened before the staleness diff).
+    assert summary["files_updated"] == 3
+    assert summary["files_removed"] == 0
+
+    # Queries against the new location resolve to real files.
+    syms = outline("a.py", root=moved)["symbols"]
+    assert any(s["qname"] == "a:alpha" for s in syms)
+
+
 def test_deleted_file_is_removed_from_index(tmp_path: Path) -> None:
     root = tmp_path / "repo"
     _write_repo(root)

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,0 +1,193 @@
+"""On-demand vendor-package indexing: discovery, query matching, and
+the cache-and-protect contract that lets the package survive subsequent
+``index_root`` refreshes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from snapctx.api import index_root, search_code
+from snapctx.api._indexer import index_subtree
+from snapctx.index import Index, db_path_for
+from snapctx.vendor import (
+    discover_packages,
+    ensure_packages_for_query,
+    match_packages,
+)
+
+
+def _make_python_pkg(root: Path, name: str, body: str = "def hello(): return 1\n") -> Path:
+    site = root / ".venv" / "lib" / "python3.14" / "site-packages"
+    pkg = site / name
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text(body)
+    return pkg
+
+
+def _make_node_pkg(root: Path, name: str) -> Path:
+    pkg = root / "node_modules" / name
+    pkg.mkdir(parents=True)
+    (pkg / "index.ts").write_text("export const x = 1;\n")
+    return pkg
+
+
+def test_discover_finds_python_packages_in_venv(tmp_path: Path) -> None:
+    _make_python_pkg(tmp_path, "fakepkg")
+    found = discover_packages(tmp_path)
+    assert "fakepkg" in found
+    assert found["fakepkg"].name == "fakepkg"
+
+
+def test_discover_skips_dist_info_and_dotfiles(tmp_path: Path) -> None:
+    site = tmp_path / ".venv" / "lib" / "python3.14" / "site-packages"
+    site.mkdir(parents=True)
+    (site / "fakepkg-1.0.dist-info").mkdir()
+    (site / "fakepkg-1.0.egg-info").mkdir()
+    (site / ".hidden").mkdir()
+    (site / "_internal").mkdir()
+    (site / "real").mkdir()
+    found = discover_packages(tmp_path)
+    assert set(found) == {"real"}
+
+
+def test_discover_finds_node_modules(tmp_path: Path) -> None:
+    _make_node_pkg(tmp_path, "react")
+    found = discover_packages(tmp_path)
+    assert "react" in found
+
+
+def test_discover_skips_scoped_node_packages(tmp_path: Path) -> None:
+    """v1: scoped packages are intentionally out of scope."""
+    (tmp_path / "node_modules" / "@types").mkdir(parents=True)
+    _make_node_pkg(tmp_path, "react")
+    found = discover_packages(tmp_path)
+    assert "@types" not in found
+    assert "react" in found
+
+
+def test_match_packages_is_token_exact_not_substring(tmp_path: Path) -> None:
+    """``model`` should NOT match ``modeling`` — substring matches would
+    constantly false-positive on common English words."""
+    pkgs = {"model": Path("/dev/null"), "django": Path("/dev/null")}
+    assert match_packages("how does modeling work", pkgs) == []
+    assert match_packages("django model definition", pkgs) == [
+        ("model", Path("/dev/null")),
+        ("django", Path("/dev/null")),
+    ] or match_packages("django model definition", pkgs) == [
+        ("django", Path("/dev/null")),
+        ("model", Path("/dev/null")),
+    ]
+
+
+def test_match_packages_case_insensitive(tmp_path: Path) -> None:
+    pkgs = {"django": Path("/dev/null")}
+    assert match_packages("Django QuerySet", pkgs) == [("django", Path("/dev/null"))]
+
+
+def test_index_subtree_ingests_only_the_subtree(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    pkg = _make_python_pkg(tmp_path, "fakepkg", body="def fake_helper(): return 42\n")
+    # Index the project (without vendor toggle, so fakepkg is skipped).
+    index_root(tmp_path)
+    # On-demand subtree pass.
+    summary = index_subtree(tmp_path, pkg)
+    assert summary["files_updated"] >= 1
+    # fake_helper should now be queryable.
+    res = search_code("fake_helper", k=3, root=tmp_path)
+    qnames = [r["qname"] for r in res["results"]]
+    assert any("fake_helper" in q for q in qnames)
+
+
+def test_ensure_packages_marks_indexed_and_skips_second_time(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    _make_python_pkg(tmp_path, "fakepkg")
+    index_root(tmp_path)
+
+    first = ensure_packages_for_query(tmp_path, "fakepkg please", enable_auto=True)
+    assert len(first) == 1
+    assert first[0]["package"] == "fakepkg"
+
+    # Marker present.
+    idx = Index(db_path_for(tmp_path))
+    try:
+        assert idx.is_vendor_indexed("fakepkg")
+    finally:
+        idx.close()
+
+    # Second call: package already indexed, no work done.
+    second = ensure_packages_for_query(tmp_path, "fakepkg again", enable_auto=True)
+    assert second == []
+
+
+def test_index_root_preserves_indexed_vendor_packages(tmp_path: Path) -> None:
+    """Regression: without the vendor-prefix exemption in the staleness
+    diff, the next regular ``index_root`` would forget every django file
+    we just ingested on demand."""
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    pkg = _make_python_pkg(tmp_path, "fakepkg")
+    index_root(tmp_path)
+    ensure_packages_for_query(tmp_path, "fakepkg", enable_auto=True)
+
+    # fakepkg's files are now in the DB.
+    idx = Index(db_path_for(tmp_path))
+    try:
+        before = idx.conn.execute(
+            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ? || '%'",
+            (str(pkg),),
+        ).fetchone()["n"]
+    finally:
+        idx.close()
+    assert before >= 2  # __init__.py + core.py
+
+    # Re-run the regular index pass. fakepkg's files aren't in the walker's
+    # view (they're in .venv/, gitignored / vendor-skip), so the staleness
+    # diff would normally forget them. The vendor-prefix guard prevents that.
+    summary = index_root(tmp_path)
+    assert summary["files_removed"] == 0
+
+    idx = Index(db_path_for(tmp_path))
+    try:
+        after = idx.conn.execute(
+            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ? || '%'",
+            (str(pkg),),
+        ).fetchone()["n"]
+    finally:
+        idx.close()
+    assert after == before
+
+
+def test_forget_vendor_package_drops_files_and_marker(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    _make_python_pkg(tmp_path, "fakepkg")
+    index_root(tmp_path)
+    ensure_packages_for_query(tmp_path, "fakepkg", enable_auto=True)
+
+    idx = Index(db_path_for(tmp_path))
+    try:
+        removed = idx.forget_vendor_package("fakepkg")
+        assert removed >= 2
+        assert not idx.is_vendor_indexed("fakepkg")
+        # Project's own files untouched.
+        n_app = idx.conn.execute(
+            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ?",
+            (f"{tmp_path}/app.py",),
+        ).fetchone()["n"]
+        assert n_app == 1
+    finally:
+        idx.close()
+
+
+def test_explicit_pkg_overrides_query_token_absence(tmp_path: Path) -> None:
+    """``--pkg`` works even when the package name doesn't appear in the query."""
+    (tmp_path / "app.py").write_text("def app(): return 1\n")
+    _make_python_pkg(tmp_path, "fakepkg")
+    index_root(tmp_path)
+
+    summaries = ensure_packages_for_query(
+        tmp_path, "totally unrelated query",
+        explicit=["fakepkg"], enable_auto=False,
+    )
+    assert len(summaries) == 1
+    assert summaries[0]["package"] == "fakepkg"

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,6 +1,9 @@
-"""On-demand vendor-package indexing: discovery, query matching, and
-the cache-and-protect contract that lets the package survive subsequent
-``index_root`` refreshes.
+"""Per-package on-demand vendor indexing.
+
+Each indexed package gets its own SQLite at
+``<root>/.snapctx/vendor/<name>/index.db``. Routing is by query prefix
+(``"<pkg>: ..."``) or explicit ``--pkg`` flag — no auto-detection on
+arbitrary tokens.
 """
 
 from __future__ import annotations
@@ -8,12 +11,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from snapctx.api import index_root, search_code
-from snapctx.api._indexer import index_subtree
-from snapctx.index import Index, db_path_for
+from snapctx.api._indexer import index_vendor_package
+from snapctx.index import db_path_for
 from snapctx.vendor import (
     discover_packages,
-    ensure_packages_for_query,
-    match_packages,
+    ensure_vendor_indexed,
+    forget_vendor,
+    is_vendor_indexed,
+    list_indexed_vendors,
+    parse_query_prefix,
+    vendor_index_dir,
 )
 
 
@@ -31,6 +38,9 @@ def _make_node_pkg(root: Path, name: str) -> Path:
     pkg.mkdir(parents=True)
     (pkg / "index.ts").write_text("export const x = 1;\n")
     return pkg
+
+
+# ---------- discovery ----------
 
 
 def test_discover_finds_python_packages_in_venv(tmp_path: Path) -> None:
@@ -59,7 +69,7 @@ def test_discover_finds_node_modules(tmp_path: Path) -> None:
 
 
 def test_discover_skips_scoped_node_packages(tmp_path: Path) -> None:
-    """v1: scoped packages are intentionally out of scope."""
+    """v1: scoped @ packages are intentionally out of scope."""
     (tmp_path / "node_modules" / "@types").mkdir(parents=True)
     _make_node_pkg(tmp_path, "react")
     found = discover_packages(tmp_path)
@@ -67,127 +77,165 @@ def test_discover_skips_scoped_node_packages(tmp_path: Path) -> None:
     assert "react" in found
 
 
-def test_match_packages_is_token_exact_not_substring(tmp_path: Path) -> None:
-    """``model`` should NOT match ``modeling`` — substring matches would
-    constantly false-positive on common English words."""
-    pkgs = {"model": Path("/dev/null"), "django": Path("/dev/null")}
-    assert match_packages("how does modeling work", pkgs) == []
-    assert match_packages("django model definition", pkgs) == [
-        ("model", Path("/dev/null")),
-        ("django", Path("/dev/null")),
-    ] or match_packages("django model definition", pkgs) == [
-        ("django", Path("/dev/null")),
-        ("model", Path("/dev/null")),
-    ]
+# ---------- prefix parsing ----------
 
 
-def test_match_packages_case_insensitive(tmp_path: Path) -> None:
-    pkgs = {"django": Path("/dev/null")}
-    assert match_packages("Django QuerySet", pkgs) == [("django", Path("/dev/null"))]
+def test_prefix_routes_when_head_matches_installed_package(tmp_path: Path) -> None:
+    _make_python_pkg(tmp_path, "django")
+    scope, rest = parse_query_prefix("django: queryset filter chain", tmp_path)
+    assert scope == "django"
+    assert rest == "queryset filter chain"
 
 
-def test_index_subtree_ingests_only_the_subtree(tmp_path: Path) -> None:
-    (tmp_path / "app.py").write_text("def app(): return 1\n")
-    pkg = _make_python_pkg(tmp_path, "fakepkg", body="def fake_helper(): return 42\n")
-    # Index the project (without vendor toggle, so fakepkg is skipped).
+def test_prefix_does_not_route_when_head_is_unknown(tmp_path: Path) -> None:
+    """``foo:bar`` looks like a qname when ``foo`` isn't a real package."""
+    scope, rest = parse_query_prefix("module.path:Symbol", tmp_path)
+    assert scope is None
+    assert rest == "module.path:Symbol"
+
+
+def test_prefix_does_not_route_when_head_is_dotted(tmp_path: Path) -> None:
+    """Dotted heads are qnames, not vendor prefixes."""
+    _make_python_pkg(tmp_path, "django")
+    scope, rest = parse_query_prefix("django.db.models:QuerySet", tmp_path)
+    assert scope is None
+    assert rest == "django.db.models:QuerySet"
+
+
+def test_prefix_routes_to_already_indexed_package_even_if_uninstalled(
+    tmp_path: Path,
+) -> None:
+    """If a package was indexed before but its source dir was deleted, the
+    prefix should still route to its preserved index."""
+    pkg = _make_python_pkg(tmp_path, "ghost")
     index_root(tmp_path)
-    # On-demand subtree pass.
-    summary = index_subtree(tmp_path, pkg)
-    assert summary["files_updated"] >= 1
-    # fake_helper should now be queryable.
-    res = search_code("fake_helper", k=3, root=tmp_path)
+    ensure_vendor_indexed(tmp_path, "ghost")
+    # Wipe the source dir.
+    import shutil
+    shutil.rmtree(pkg)
+
+    scope, rest = parse_query_prefix("ghost: something", tmp_path)
+    assert scope == "ghost"
+    assert rest == "something"
+
+
+# ---------- per-package index lifecycle ----------
+
+
+def test_index_vendor_package_writes_to_isolated_db(tmp_path: Path) -> None:
+    pkg = _make_python_pkg(tmp_path, "fakepkg", body="def fake_helper(): return 42\n")
+    index_root(tmp_path)
+    summary = index_vendor_package(tmp_path, "fakepkg", pkg)
+    assert summary["package"] == "fakepkg"
+    assert summary["files_updated"] >= 2  # __init__.py + core.py
+
+    repo_db = db_path_for(tmp_path)
+    pkg_db = db_path_for(tmp_path, scope="fakepkg")
+    assert repo_db.exists()
+    assert pkg_db.exists()
+    assert repo_db != pkg_db
+    # The package's symbols sit in the package's DB only — repo search
+    # must not see them.
+    repo_hits = search_code("fake_helper", k=5, root=tmp_path)
+    assert all("fake_helper" not in r["qname"] for r in repo_hits["results"])
+
+
+def test_search_with_scope_finds_package_symbols(tmp_path: Path) -> None:
+    _make_python_pkg(tmp_path, "fakepkg", body="def fake_helper(): return 42\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "fakepkg")
+
+    res = search_code("fake_helper", k=3, root=tmp_path, scope="fakepkg")
     qnames = [r["qname"] for r in res["results"]]
     assert any("fake_helper" in q for q in qnames)
 
 
-def test_ensure_packages_marks_indexed_and_skips_second_time(tmp_path: Path) -> None:
-    (tmp_path / "app.py").write_text("def app(): return 1\n")
+def test_vendor_qnames_are_rooted_at_package_not_repo(tmp_path: Path) -> None:
+    """Per-package re-rooting: qnames inside a vendor index look like the
+    package's module structure, not ``.venv.lib.pythonX.Y...`` prefixes."""
+    _make_python_pkg(tmp_path, "fakepkg", body="def fake_helper(): return 42\n")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "fakepkg")
+
+    res = search_code("fake_helper", k=3, root=tmp_path, scope="fakepkg")
+    qnames = [r["qname"] for r in res["results"]]
+    # Should be like "core:fake_helper", not "<long.venv.path>:fake_helper".
+    assert any(q.startswith("core:") for q in qnames), qnames
+
+
+def test_ensure_vendor_indexed_is_idempotent(tmp_path: Path) -> None:
     _make_python_pkg(tmp_path, "fakepkg")
     index_root(tmp_path)
 
-    first = ensure_packages_for_query(tmp_path, "fakepkg please", enable_auto=True)
-    assert len(first) == 1
-    assert first[0]["package"] == "fakepkg"
+    first = ensure_vendor_indexed(tmp_path, "fakepkg")
+    assert first is not None
+    assert first["files_updated"] >= 2
 
-    # Marker present.
-    idx = Index(db_path_for(tmp_path))
-    try:
-        assert idx.is_vendor_indexed("fakepkg")
-    finally:
-        idx.close()
-
-    # Second call: package already indexed, no work done.
-    second = ensure_packages_for_query(tmp_path, "fakepkg again", enable_auto=True)
-    assert second == []
+    # Already indexed — second call returns None without rebuilding.
+    second = ensure_vendor_indexed(tmp_path, "fakepkg")
+    assert second is None
 
 
-def test_index_root_preserves_indexed_vendor_packages(tmp_path: Path) -> None:
-    """Regression: without the vendor-prefix exemption in the staleness
-    diff, the next regular ``index_root`` would forget every django file
-    we just ingested on demand."""
-    (tmp_path / "app.py").write_text("def app(): return 1\n")
-    pkg = _make_python_pkg(tmp_path, "fakepkg")
+def test_ensure_vendor_indexed_unknown_package_returns_none(tmp_path: Path) -> None:
     index_root(tmp_path)
-    ensure_packages_for_query(tmp_path, "fakepkg", enable_auto=True)
-
-    # fakepkg's files are now in the DB.
-    idx = Index(db_path_for(tmp_path))
-    try:
-        before = idx.conn.execute(
-            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ? || '%'",
-            (str(pkg),),
-        ).fetchone()["n"]
-    finally:
-        idx.close()
-    assert before >= 2  # __init__.py + core.py
-
-    # Re-run the regular index pass. fakepkg's files aren't in the walker's
-    # view (they're in .venv/, gitignored / vendor-skip), so the staleness
-    # diff would normally forget them. The vendor-prefix guard prevents that.
-    summary = index_root(tmp_path)
-    assert summary["files_removed"] == 0
-
-    idx = Index(db_path_for(tmp_path))
-    try:
-        after = idx.conn.execute(
-            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ? || '%'",
-            (str(pkg),),
-        ).fetchone()["n"]
-    finally:
-        idx.close()
-    assert after == before
+    result = ensure_vendor_indexed(tmp_path, "not_installed")
+    assert result is None
+    assert not is_vendor_indexed(tmp_path, "not_installed")
 
 
-def test_forget_vendor_package_drops_files_and_marker(tmp_path: Path) -> None:
-    (tmp_path / "app.py").write_text("def app(): return 1\n")
-    _make_python_pkg(tmp_path, "fakepkg")
+def test_list_indexed_vendors_reflects_directory(tmp_path: Path) -> None:
+    _make_python_pkg(tmp_path, "alpha")
+    _make_python_pkg(tmp_path, "beta")
     index_root(tmp_path)
-    ensure_packages_for_query(tmp_path, "fakepkg", enable_auto=True)
+    assert list_indexed_vendors(tmp_path) == []
 
-    idx = Index(db_path_for(tmp_path))
-    try:
-        removed = idx.forget_vendor_package("fakepkg")
-        assert removed >= 2
-        assert not idx.is_vendor_indexed("fakepkg")
-        # Project's own files untouched.
-        n_app = idx.conn.execute(
-            "SELECT COUNT(*) AS n FROM files WHERE path LIKE ?",
-            (f"{tmp_path}/app.py",),
-        ).fetchone()["n"]
-        assert n_app == 1
-    finally:
-        idx.close()
+    ensure_vendor_indexed(tmp_path, "alpha")
+    assert list_indexed_vendors(tmp_path) == ["alpha"]
+
+    ensure_vendor_indexed(tmp_path, "beta")
+    assert list_indexed_vendors(tmp_path) == ["alpha", "beta"]
 
 
-def test_explicit_pkg_overrides_query_token_absence(tmp_path: Path) -> None:
-    """``--pkg`` works even when the package name doesn't appear in the query."""
-    (tmp_path / "app.py").write_text("def app(): return 1\n")
+def test_forget_vendor_removes_only_that_packages_index(tmp_path: Path) -> None:
+    _make_python_pkg(tmp_path, "alpha")
+    _make_python_pkg(tmp_path, "beta")
+    index_root(tmp_path)
+    ensure_vendor_indexed(tmp_path, "alpha")
+    ensure_vendor_indexed(tmp_path, "beta")
+
+    assert forget_vendor(tmp_path, "alpha") is True
+    assert not is_vendor_indexed(tmp_path, "alpha")
+    assert is_vendor_indexed(tmp_path, "beta")
+    # Forgetting again is a no-op.
+    assert forget_vendor(tmp_path, "alpha") is False
+
+
+def test_repo_index_unaffected_by_vendor_indexing(tmp_path: Path) -> None:
+    """Indexing a vendor package must not write to the repo's DB."""
+    (tmp_path / "app.py").write_text("def app_only(): return 1\n")
     _make_python_pkg(tmp_path, "fakepkg")
     index_root(tmp_path)
 
-    summaries = ensure_packages_for_query(
-        tmp_path, "totally unrelated query",
-        explicit=["fakepkg"], enable_auto=False,
-    )
-    assert len(summaries) == 1
-    assert summaries[0]["package"] == "fakepkg"
+    repo_files_before = _count_files(tmp_path, scope=None)
+    ensure_vendor_indexed(tmp_path, "fakepkg")
+    repo_files_after = _count_files(tmp_path, scope=None)
+    assert repo_files_before == repo_files_after
+
+
+def _count_files(root: Path, scope: str | None) -> int:
+    import sqlite3
+    db = db_path_for(root, scope=scope)
+    if not db.exists():
+        return 0
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_vendor_index_dir_layout(tmp_path: Path) -> None:
+    """``.snapctx/vendor/<name>/index.db`` is the canonical path."""
+    expected = tmp_path / ".snapctx" / "vendor" / "django" / "index.db"
+    assert db_path_for(tmp_path, scope="django") == expected.resolve()
+    assert vendor_index_dir(tmp_path, "django") == expected.parent.resolve()


### PR DESCRIPTION
## Summary

Adds query-driven on-demand indexing of third-party packages with per-package isolated indexes, prefix-based routing, and lazy cross-package call-graph stitching.

## What's in here (4 commits)

1. **walker: add skip_vendor_packages toggle** — splits ALWAYS_SKIP into truly-always-skipped dirs (.git, build artifacts) and toggleable VENDOR_PACKAGE_DIRS (.venv, node_modules). Default unchanged.
2. **vendor: index third-party packages on demand from query tokens** (v1, superseded by #3) — also fixes a latent transaction-nesting bug and adds rename detection.
3. **vendor: per-package isolated indexes, prefix-based routing** — replaces the merged-index design. Each indexed package gets `<root>/.snapctx/vendor/<name>/index.db`. Query syntax: `"django: queryset filter"` routes to the django index. No prefix → repo only. 3× faster scoped queries (skip repo refresh).
4. **graph: stitch the call graph across indexed vendor packages** — when `expand`/`context` hits a call resolved-to-NULL whose target was imported from another *also-indexed* package, follow the import to that sibling index. Demonstrated on django→asgiref: `Task.call → async_to_sync` now resolves to `sync:async_to_sync [pkg=asgiref]`.

## Validation

168 tests pass (was 142). New suites: `test_vendor.py` (17 tests for discovery + routing + lifecycle), `test_cross_package.py` (9 tests for resolver edge cases).

End-to-end on real repos:
- biblereader/backend (Python+Django): ✓ scope routing, qnames, cross-package edges
- zustand (TypeScript): ✓ index 51 files in 1.3 s, warm query 0.35 s
- shadcn/ui (React monorepo): ✓ index 3,543 files in 49 s, warm query 0.66 s

## Test plan

- [x] Run `pytest tests/`
- [x] Run a prefixed query (`snapctx context "django: queryset filter"`) on a project with django installed — verify cross-namespace isolation
- [x] Run an unprefixed query — verify repo-only results, no vendor pollution
- [x] Time subsequent scoped queries — ~350 ms warm
- [x] Verify cross-package edges resolve when both packages are indexed (django → asgiref)
- [x] Verify cross-package edges stay unresolved when target package isn't indexed (explicit-prefix rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)