### PR TITLE
parsers: add shell (bash/sh) parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Structured codebase context for AI agents.** One tool call replaces the agent's usual loop of `grep` + `read` + chase imports. Point it at a codebase; ask a natural-language question; get back a self-contained context pack — top symbols, their signatures, their docstrings, a **depth-2 call-path trace**, module-level architectural docstrings, and the full source of the top matches — in single-digit ms per query once warm.
 
-Python, TypeScript, TSX, and JSX today. Parser layer is pluggable — more languages are straight additions.
+Python, TypeScript, TSX, JSX, and shell (`.sh`/`.bash`) today. Parser layer is pluggable — more languages are straight additions.
 
 ---
 
@@ -123,8 +123,8 @@ respect_gitignore    = true      # honor .gitignore
 max_file_size        = 256000    # bytes; default 250 KiB
 
 # Restrict to specific parsers (default: every parser is active).
-# Valid values: "python", "typescript".
-languages = ["python", "typescript"]
+# Valid values: "python", "typescript", "shell".
+languages = ["python", "typescript", "shell"]
 ```
 
 Unknown keys are tolerated for forward-compatibility; type errors on known keys raise with the file path so they're easy to fix.
@@ -501,6 +501,7 @@ pack = context_multi("login session", roots, anchor=Path("."))
 **Indexed:**
 - **Python:** functions and methods (`def`, `async def`, including nested / closure definitions); classes (with base-class list for MRO-aware `self.X` resolution); module-level constants (`UPPER_CASE = literal | identifier | collection`); class-level constants (`class C: STATUS_CHOICES = [...]`); imports (for call-site resolution).
 - **TypeScript / TSX / JSX:** functions and arrow-const functions; classes (with `extends` / `implements` base chain); interfaces and type aliases; enums; React components (capitalized name + JSX in body); module-scope typed constants. JSX usage is tracked as a call edge (`<Button />` → `Button:Button`).
+- **Shell (`.sh`, `.bash`):** module symbol per script (with leading-comment block as docstring); function definitions in both POSIX (`name() { … }`) and ksh (`function name { … }`) form; `source` / `.` directives as imports; intra-script function calls as call edges. Call detection skips external binaries (`aws`, `docker`, `git`) — they're not symbols in any indexable sense.
 - **Module docstrings** — Python files with a top string docstring and TS/JSX files opening with a `/** … */` block. This captures the architectural "why" of a file, which often isn't repeated on any single class or function.
 - **Call edges**, with optimistic `self.X` resolution through base classes, plus a post-ingest *promote* pass that fixes up forward references (methods defined later in the class body than their caller).
 
@@ -532,6 +533,7 @@ snapctx/
       base.py           # Parser protocol (language-agnostic)
       python.py         # stdlib ast implementation
       typescript.py     # tree-sitter TS + TSX grammars (JSX-aware)
+      shell.py          # regex-based bash/sh parser (functions, source, calls)
       registry.py       # extension → parser dispatch
     walker.py           # gitignore-aware file walker + bundle/size filters
     index.py            # SQLite schema, FTS5, vector BLOB, promote/demote passes
@@ -565,7 +567,7 @@ uv pip install --group dev      # or: uv pip install pytest
 pytest
 ```
 
-170+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
+180+ tests currently pass. First run downloads the ONNX embedding model (~30 MB, cached under `~/.cache/huggingface/`).
 
 ---
 

--- a/src/snapctx/parsers/registry.py
+++ b/src/snapctx/parsers/registry.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from snapctx.parsers.base import Parser
 from snapctx.parsers.python import PythonParser
+from snapctx.parsers.shell import ShellParser
 from snapctx.parsers.typescript import TypeScriptParser
 
-_PARSERS: list[Parser] = [PythonParser(), TypeScriptParser()]
+_PARSERS: list[Parser] = [PythonParser(), TypeScriptParser(), ShellParser()]
 
 _BY_EXT: dict[str, Parser] = {
     ext: p for p in _PARSERS for ext in p.extensions

--- a/src/snapctx/parsers/shell.py
+++ b/src/snapctx/parsers/shell.py
@@ -1,0 +1,344 @@
+"""Shell-script parser (.sh, .bash).
+
+Extracts:
+
+- **module** — the script as a whole, with its leading comment block as
+  the docstring (the closest thing shell has to one).
+- **function** — every function definition. Both POSIX (``name() { … }``)
+  and ksh-style (``function name { … }`` or ``function name() { … }``).
+  Body extent found via brace-depth tracking that respects single-/
+  double-quoted strings and ``#`` end-of-line comments.
+- **import** — ``source <file>`` and ``. <file>`` directives. Module
+  path is recorded relative to the script (``./lib/util.sh`` →
+  ``lib/util``) so cross-script lookups work the same way as Python's
+  dotted imports.
+- **call** — invocations of *intra-file* functions. We can only
+  resolve calls to functions also defined in this script (the parser
+  doesn't see what other sourced files contain). Calls to external
+  binaries (``aws``, ``docker``, ``git``) are intentionally not emitted —
+  they aren't symbols in any indexable sense.
+
+Known limitations:
+
+- Heredocs (``<<EOF … EOF``) aren't tracked when matching braces; a
+  heredoc body containing an unbalanced ``{`` would confuse function-
+  end detection. Rare enough in practice that we don't pay tree-sitter's
+  weight to fix it for v1.
+- Functions defined inside other functions (nested) get the same
+  parent_qname as top-level ones; shell's lexical scoping is loose
+  enough that this rarely matters for retrieval.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from snapctx.qname import make_qname, typescript_module_path
+from snapctx.schema import Call, Import, ParseResult, Symbol
+
+
+# Function definition forms. We deliberately stop *before* the body-
+# opening ``{`` so the post-match ``find("{", end)`` can locate it
+# unambiguously. Two alternatives:
+#   POSIX:   ``[function ]name() …``    — name in group 1
+#   KSH:     ``function name …``         — name in group 2
+_FUNC_RE = re.compile(
+    r"""
+    ^[ \t]*
+    (?:
+        (?:function[ \t]+)?              # optional 'function' keyword
+        ([A-Za-z_][A-Za-z0-9_\-]*)       # 1: POSIX name
+        [ \t]*\(\)                       # parens
+      |
+        function[ \t]+
+        ([A-Za-z_][A-Za-z0-9_\-]*)       # 2: ksh name
+        (?![ \t]*\()                     # not followed by parens (handled above)
+    )
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+_SOURCE_RE = re.compile(
+    r"""
+    ^[ \t]*
+    (?:source|\.)[ \t]+              # ``source`` or ``.``
+    ['"]?                            # optional quote
+    ([^\s'";]+)                      # group 1: path
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+class ShellParser:
+    """Parser entry point. Implements ``parsers.base.Parser`` protocol."""
+
+    language = "shell"
+    extensions = (".sh", ".bash")
+
+    def parse(self, path: Path, root: Path) -> ParseResult:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        module = typescript_module_path(path, root)  # slash-separated, like .ts
+        file_str = str(path.resolve())
+
+        symbols: list[Symbol] = []
+        calls: list[Call] = []
+        imports: list[Import] = []
+
+        # Module-level symbol — the whole script. Leading comment block
+        # (after an optional shebang) is the closest thing to a docstring.
+        line_count = source.count("\n") + (0 if source.endswith("\n") else 1)
+        module_qname = make_qname(module, [])
+        symbols.append(Symbol(
+            qname=module_qname,
+            kind="module",
+            language=self.language,
+            signature=f"shell script {module}",
+            docstring=_leading_comment_block(source),
+            file=file_str,
+            line_start=1,
+            line_end=max(1, line_count),
+            parent_qname=None,
+            source_sha=_sha(source),
+        ))
+
+        # Function definitions — find each header, then locate the
+        # matching closing brace.
+        functions = list(_iter_functions(source))
+        defined_names = {name for name, _, _ in functions}
+        for name, header_line, header_end_pos in functions:
+            body_start_pos = source.find("{", header_end_pos)
+            if body_start_pos < 0:
+                continue
+            end_pos = _match_brace(source, body_start_pos)
+            if end_pos < 0:
+                continue
+            line_start = source.count("\n", 0, header_end_pos) + 1
+            line_end = source.count("\n", 0, end_pos) + 1
+            body = source[body_start_pos + 1 : end_pos]
+
+            qname = make_qname(module, [name])
+            symbols.append(Symbol(
+                qname=qname,
+                kind="function",
+                language=self.language,
+                signature=f"{name}()",
+                docstring=_leading_comment_block_before(source, header_line),
+                file=file_str,
+                line_start=line_start,
+                line_end=line_end,
+                parent_qname=module_qname,
+                source_sha=_sha(body),
+            ))
+
+            # Intra-file function calls: scan the body for tokens that
+            # match a defined function name at command position (start of
+            # a statement). Bash command position = start of a logical
+            # line, after ``;``, ``&&``, ``||``, ``|``, or ``$( ``.
+            for call_name, call_line_offset in _find_command_tokens(
+                body, defined_names - {name}
+            ):
+                calls.append(Call(
+                    caller_qname=qname,
+                    callee_name=call_name,
+                    callee_qname=make_qname(module, [call_name]),
+                    file=file_str,
+                    line=line_start + call_line_offset,
+                ))
+
+        # source / dot imports.
+        for m in _SOURCE_RE.finditer(source):
+            raw = m.group(1)
+            line = source.count("\n", 0, m.start()) + 1
+            imports.append(Import(
+                file=file_str,
+                module=_normalize_source_path(raw),
+                name=None,
+                alias=None,
+                line=line,
+            ))
+
+        return ParseResult(
+            symbols=symbols, calls=calls, imports=imports, language=self.language,
+        )
+
+
+# ---------- helpers ----------
+
+
+def _iter_functions(source: str):
+    """Yield (name, header_line_no, header_end_pos) for each function header."""
+    for m in _FUNC_RE.finditer(source):
+        name = m.group(1) or m.group(2)
+        if not name:
+            continue
+        line_no = source.count("\n", 0, m.start()) + 1
+        yield name, line_no, m.end()
+
+
+def _match_brace(source: str, open_pos: int) -> int:
+    """Return index of the ``}`` that closes the ``{`` at ``open_pos``.
+
+    Tracks single- and double-quoted strings (with ``\\`` escape inside
+    double quotes) and ``#`` end-of-line comments so braces inside those
+    don't confuse depth counting. Returns -1 if no match found.
+    """
+    depth = 0
+    i = open_pos
+    n = len(source)
+    while i < n:
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+            i += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+            i += 1
+        elif ch == "'":
+            j = source.find("'", i + 1)
+            if j < 0:
+                return -1
+            i = j + 1
+        elif ch == '"':
+            i += 1
+            while i < n:
+                if source[i] == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if source[i] == '"':
+                    i += 1
+                    break
+                i += 1
+        elif ch == "#":
+            # Comment to end of line; only counts as a comment when at
+            # token start (after whitespace, ``;``, ``\n``, etc.).
+            if i == 0 or source[i - 1] in " \t\n;|&(":
+                j = source.find("\n", i)
+                i = n if j < 0 else j + 1
+            else:
+                i += 1
+        else:
+            i += 1
+    return -1
+
+
+_COMMAND_BREAKERS = "\n;&|()`"
+
+
+def _find_command_tokens(body: str, names: set[str]):
+    """Yield (name, line_offset) for each call to a name in ``names`` at
+    command position within ``body``. Line offsets are 0-based relative
+    to the start of the body.
+    """
+    if not names:
+        return
+    n = len(body)
+    i = 0
+    at_command_start = True
+    while i < n:
+        ch = body[i]
+        if ch == "\n":
+            at_command_start = True
+            i += 1
+            continue
+        if ch in _COMMAND_BREAKERS:
+            at_command_start = True
+            i += 1
+            continue
+        if ch in " \t":
+            i += 1
+            continue
+        if ch == "#":
+            j = body.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if ch == "'":
+            j = body.find("'", i + 1)
+            i = n if j < 0 else j + 1
+            at_command_start = False
+            continue
+        if ch == '"':
+            i += 1
+            while i < n:
+                if body[i] == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if body[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            at_command_start = False
+            continue
+        # Identifier?
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < n and (body[j].isalnum() or body[j] in "_-"):
+                j += 1
+            tok = body[i:j]
+            if at_command_start and tok in names:
+                line_offset = body.count("\n", 0, i)
+                yield tok, line_offset
+            at_command_start = False
+            i = j
+            continue
+        at_command_start = False
+        i += 1
+
+
+def _normalize_source_path(raw: str) -> str:
+    """Normalize a sourced-file path into a slash-separated module form
+    matching ``typescript_module_path`` output (extension stripped).
+    """
+    p = raw.lstrip("./")
+    for ext in (".sh", ".bash"):
+        if p.endswith(ext):
+            p = p[: -len(ext)]
+            break
+    return p
+
+
+def _leading_comment_block(source: str) -> str | None:
+    """Return the leading comment block as a docstring, ignoring shebangs."""
+    lines = source.splitlines()
+    out: list[str] = []
+    for line in lines:
+        s = line.strip()
+        if s.startswith("#!"):
+            continue
+        if s.startswith("#"):
+            out.append(s.lstrip("#").lstrip())
+            continue
+        if not s:
+            if out:
+                break
+            continue
+        break
+    if not out:
+        return None
+    return "\n".join(out).strip() or None
+
+
+def _leading_comment_block_before(source: str, header_line: int) -> str | None:
+    """Return any contiguous ``# …`` lines immediately above the header line."""
+    lines = source.splitlines()
+    if header_line < 2:
+        return None
+    out: list[str] = []
+    for i in range(header_line - 2, -1, -1):
+        s = lines[i].strip()
+        if s.startswith("#"):
+            out.append(s.lstrip("#").lstrip())
+            continue
+        if not s:
+            break
+        break
+    if not out:
+        return None
+    return "\n".join(reversed(out)).strip() or None
+
+
+def _sha(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()

--- a/tests/test_shell_parser.py
+++ b/tests/test_shell_parser.py
@@ -1,0 +1,203 @@
+"""Shell-script parser: function detection, intra-script call edges,
+``source``/``.`` imports, and module-level docstring extraction.
+
+Tests use ``tmp_path`` and exercise the parser via ``index_root`` (so
+walker → parser → index integration is covered too).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from snapctx.api import index_root, outline, search_code
+from snapctx.parsers.shell import ShellParser
+
+
+def _write(root: Path, name: str, body: str) -> Path:
+    p = root / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    return p
+
+
+def test_module_symbol_with_leading_comment_docstring(tmp_path: Path) -> None:
+    f = _write(tmp_path, "deploy.sh", (
+        "#!/bin/bash\n"
+        "# Deploys the staging environment.\n"
+        "# Reads AWS credentials from ~/.aws.\n"
+        "\n"
+        "echo hi\n"
+    ))
+    parser = ShellParser()
+    result = parser.parse(f, tmp_path)
+
+    modules = [s for s in result.symbols if s.kind == "module"]
+    assert len(modules) == 1
+    m = modules[0]
+    assert m.qname == "deploy:"
+    assert m.docstring is not None
+    assert "staging" in m.docstring
+    assert "AWS" in m.docstring
+
+
+def test_posix_function_definition(tmp_path: Path) -> None:
+    f = _write(tmp_path, "lib.sh", (
+        "setup() {\n"
+        "    echo 'setting up'\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    funcs = [s for s in result.symbols if s.kind == "function"]
+    assert len(funcs) == 1
+    assert funcs[0].qname == "lib:setup"
+    assert funcs[0].parent_qname == "lib:"
+
+
+def test_ksh_function_definition(tmp_path: Path) -> None:
+    """``function NAME { … }`` (no parens) is a valid bash form."""
+    f = _write(tmp_path, "lib.sh", (
+        "function deploy {\n"
+        "    echo 'deploying'\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    funcs = [s for s in result.symbols if s.kind == "function"]
+    assert any(s.qname == "lib:deploy" for s in funcs)
+
+
+def test_function_docstring_from_preceding_comments(tmp_path: Path) -> None:
+    f = _write(tmp_path, "ops.sh", (
+        "# Restart the worker.\n"
+        "# Waits 5s for graceful shutdown.\n"
+        "restart_worker() {\n"
+        "    kill $WORKER_PID\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    fn = next(s for s in result.symbols if s.qname == "ops:restart_worker")
+    assert fn.docstring is not None
+    assert "Restart" in fn.docstring
+    assert "graceful" in fn.docstring
+
+
+def test_intra_script_call_resolves_to_qname(tmp_path: Path) -> None:
+    f = _write(tmp_path, "deploy.sh", (
+        "setup_aws() {\n"
+        "    echo 'aws'\n"
+        "}\n"
+        "\n"
+        "deploy() {\n"
+        "    setup_aws\n"
+        "    echo 'deploying'\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    deploy_calls = [c for c in result.calls if c.caller_qname == "deploy:deploy"]
+    assert len(deploy_calls) == 1
+    assert deploy_calls[0].callee_name == "setup_aws"
+    assert deploy_calls[0].callee_qname == "deploy:setup_aws"
+
+
+def test_external_command_is_not_emitted_as_call(tmp_path: Path) -> None:
+    """``aws s3 cp`` shouldn't become a call edge — ``aws`` is an
+    external binary, not a defined function."""
+    f = _write(tmp_path, "deploy.sh", (
+        "deploy() {\n"
+        "    aws s3 cp file s3://bucket/\n"
+        "    docker build .\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    callees = {c.callee_name for c in result.calls}
+    assert "aws" not in callees
+    assert "docker" not in callees
+
+
+def test_source_directive_emits_import(tmp_path: Path) -> None:
+    f = _write(tmp_path, "main.sh", (
+        "source ./lib/util.sh\n"
+        ". ./helpers.sh\n"
+        "echo done\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    modules = sorted(i.module for i in result.imports)
+    assert modules == ["helpers", "lib/util"]
+
+
+def test_brace_in_string_doesnt_break_function_extent(tmp_path: Path) -> None:
+    """A ``}`` inside a quoted string mustn't be treated as the end of
+    the function body."""
+    f = _write(tmp_path, "tricky.sh", (
+        "make_json() {\n"
+        '    echo "{ \\"k\\": \\"v\\" }"\n'
+        "    echo 'a } b'\n"
+        "    echo done\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    fn = next(s for s in result.symbols if s.qname == "tricky:make_json")
+    # The function's line range should cover the whole body, including
+    # the line with the ``}`` inside the string.
+    assert fn.line_end - fn.line_start >= 4
+
+
+def test_call_inside_pipeline_is_detected(tmp_path: Path) -> None:
+    """Bash pipelines and command chains: ``setup && deploy`` —
+    ``deploy`` is also at command position after ``&&``."""
+    f = _write(tmp_path, "ci.sh", (
+        "setup() { echo s; }\n"
+        "deploy() { echo d; }\n"
+        "main() {\n"
+        "    setup && deploy\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    main_calls = {c.callee_name for c in result.calls if c.caller_qname == "ci:main"}
+    assert main_calls == {"setup", "deploy"}
+
+
+def test_call_in_comment_is_ignored(tmp_path: Path) -> None:
+    f = _write(tmp_path, "ci.sh", (
+        "setup() { echo s; }\n"
+        "main() {\n"
+        "    # call setup here later\n"
+        "    echo todo\n"
+        "}\n"
+    ))
+    result = ShellParser().parse(f, tmp_path)
+    main_calls = [c for c in result.calls if c.caller_qname == "ci:main"]
+    assert main_calls == []
+
+
+def test_index_root_picks_up_shell_files(tmp_path: Path) -> None:
+    """End-to-end: walker + parser registry actually ingest .sh files."""
+    _write(tmp_path, "scripts/deploy.sh", (
+        "deploy() { echo deploying; }\n"
+    ))
+    _write(tmp_path, "app.py", "def main(): pass\n")
+
+    summary = index_root(tmp_path)
+    assert summary["files_updated"] >= 2
+
+    res = search_code("deploy", k=5, root=tmp_path)
+    qnames = {r["qname"] for r in res["results"]}
+    assert "scripts/deploy:deploy" in qnames
+
+
+def test_outline_of_shell_file(tmp_path: Path) -> None:
+    f = _write(tmp_path, "ops.sh", (
+        "setup() { echo s; }\n"
+        "deploy() { echo d; }\n"
+        "teardown() { echo t; }\n"
+    ))
+    index_root(tmp_path)
+
+    out = outline(f, root=tmp_path)
+    qnames = {s["qname"] for s in out["symbols"]}
+    children = {
+        c["qname"]
+        for s in out["symbols"]
+        for c in s.get("children", [])
+    }
+    assert "ops:" in qnames  # module
+    assert {"ops:setup", "ops:deploy", "ops:teardown"} <= children


### PR DESCRIPTION
## Summary

Adds a regex-based parser for `.sh` / `.bash` so shell scripts get the same Symbol / Call / Import treatment as Python and TypeScript. Search, expand, context, and outline all work uniformly.

## What's extracted

- **Module symbol** per script, with the leading comment block (after any shebang) as the docstring.
- **Function definitions** in both POSIX (`name() { … }`) and ksh (`function name { … }`) forms; preceding `# …` lines become the function's docstring.
- **`source` / `.` directives** as imports (`./lib/util.sh` → module `lib/util`).
- **Intra-script function calls** as resolved call edges. External binaries (`aws`, `docker`, `git`) are intentionally not emitted — they aren't symbols.

Brace matching is string- and comment-aware so `"{ \"k\": \"v\" }"` inside a function doesn't end the body early.

## Validation

180 tests pass (was 168). End-to-end on biblereader/backend's `scripts/backup.sh` (10 functions, 100+ LoC):
- `outline scripts/backup.sh` correctly nests every function under the module
- `context "backup database to s3"` lands on `sync_to_s3`, `download_from_s3`, `backup_database` with their intra-script callees resolved
- `expand scripts/backup:main` walks all 8 helper calls

## Test plan

- [x] `pytest tests/`
- [x] Index a project with shell scripts; verify outline/search/expand
- [x] Confirm comments-only references aren't emitted as calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)