### PR TITLE
docs: spell out 'snapctx' = snap context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python: 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
+*snapctx = **snap** **c**on**t**e**x**t — a snapshot of the context an agent needs.*
+
 **Structured codebase context for AI agents.** One CLI call replaces the agent's usual `grep` + `read` + chase-imports loop. Ask a natural-language question; get back a self-contained pack of top symbols, their source, callees, callers, and module-level docstrings. **1 tool call vs 11–18, up to 22× fewer tokens** on cross-cutting audit-style questions ([measured](#why-bother-the-numbers)).
 
 Languages today: Python, TypeScript, TSX, JSX, and shell (`.sh`/`.bash`). The parser layer is pluggable — adding a language is a single new file.


### PR DESCRIPTION
Adds a one-liner under the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)